### PR TITLE
Write Json in utf-8 rather than Unicode

### DIFF
--- a/newsplease/pipeline/pipelines.py
+++ b/newsplease/pipeline/pipelines.py
@@ -375,7 +375,7 @@ class JsonFileStorage(ExtractedInformationStorage):
 
         # Write JSON to local file system
         with open(file_path, 'w') as file_:
-            json.dump(ExtractedInformationStorage.extract_relevant_info(item), file_)
+            json.dump(ExtractedInformationStorage.extract_relevant_info(item), file_, ensure_ascii=False)
 
         return item
 


### PR DESCRIPTION
There is an issue when dealing with Cyrillic alphabet. By default JSON dumps it into Unicode. Added line of code fixes it.