### PR TITLE
bug fix in commoncrawl_crawler.py.__get_publishing_date

### DIFF
--- a/newsplease/crawler/commoncrawl_crawler.py
+++ b/newsplease/crawler/commoncrawl_crawler.py
@@ -59,11 +59,8 @@ def __get_publishing_date(warc_record, article):
     :param warc_record:
     :return:
     """
-    if article.publish_date:
-        return parser.parse(article.publish_date)
-    else:
-        return None
-
+    return article.date_publish
+    
 
 def __get_download_url(name):
     """


### PR DESCRIPTION
Without the change the code emits the error `NewsArticle is not iterable`. I also removed `parser.parse()` because the `.publish_date` is already `datetime` instance