### PR TITLE
make compatible with Elasticsearch 6.x

### DIFF
--- a/newsplease/config/config.cfg
+++ b/newsplease/config/config.cfg
@@ -209,26 +209,26 @@ username = 'root'
 secret = 'password'
 
 # Properties of the document type used for storage.
-mapping = {
-    'url': {'type': 'string', 'index': 'not_analyzed'},
-    'source_domain': {'type': 'string', 'index': 'not_analyzed'},
-    'title_page': {'type': 'string'},
-    'title_rss': {'type': 'string'},
-    'localpath': {'type': 'string', 'index' : 'not_analyzed'},
-    'filename': {'type': 'string', 'index' : 'not_analyzed'},
-    'ancestor': {'type': 'string'},
-    'descendant': {'type': 'string'},
-    'version': {'type': 'long'},
-    'date_download': {'type': 'date', "format":"yyyy-MM-dd HH:mm:ss"},
-    'date_modify': {'type': 'date', "format":"yyyy-MM-dd HH:mm:ss"},
-    'date_publish': {'type': 'date', "format":"yyyy-MM-dd HH:mm:ss"},
-    'title': {'type': 'string'},
-    'description': {'type': 'string'},
-    'text': {'type': 'string'},
-    'authors': {'type': 'string'},
-    'image_url': {'type': 'string', 'index' : 'not_analyzed'},
-    'language': {'type': 'string', 'index' : 'not_analyzed'},
-    }
+mapping = {"properties": {
+    "url": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "source_domain": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "title_page": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "title_rss": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "localpath": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "filename": {"type": "keyword"},
+    "ancestor": {"type": "keyword"},
+    "descendant": {"type": "keyword"},
+    "version": {"type": "long"},
+    "date_download": {"type": "date", "format":"yyyy-MM-dd HH:mm:ss"},
+    "date_modify": {"type": "date", "format":"yyyy-MM-dd HH:mm:ss"},
+    "date_publish": {"type": "date", "format":"yyyy-MM-dd HH:mm:ss"},
+    "title": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "description":  {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "text": {"type": "text"},
+    "authors": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "image_url":  {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "language": {"type": "keyword"}
+    }}
 
 
 

--- a/newsplease/pipeline/pipelines.py
+++ b/newsplease/pipeline/pipelines.py
@@ -436,7 +436,7 @@ class ElasticsearchStorage(ExtractedInformationStorage):
                                 client_key=self.database["client_key_path"])
         self.index_current = self.database["index_current"]
         self.index_archive = self.database["index_archive"]
-        self.mapping = {'properties': self.database["mapping"]}
+        self.mapping = self.database["mapping"]
 
         # check connection to Database and set the configuration
 
@@ -452,10 +452,10 @@ class ElasticsearchStorage(ExtractedInformationStorage):
             # check if the necessary indices exist and create them if needed
             if not self.es.indices.exists(self.index_current):
                 self.es.indices.create(index=self.index_current, ignore=[400, 404])
-                self.es.indices.put_mapping(index=self.index_current, doc_type='article', body=self.mapping)
+                self.es.indices.put_mapping(index=self.index_current, doc_type='_doc', body=self.mapping)
             if not self.es.indices.exists(self.index_archive):
                 self.es.indices.create(index=self.index_archive, ignore=[400, 404])
-                self.es.indices.put_mapping(index=self.index_archive, doc_type='article', body=self.mapping)
+                self.es.indices.put_mapping(index=self.index_archive, doc_type='_doc', body=self.mapping)
             self.running = True
 
             # restore previous logging level
@@ -479,7 +479,7 @@ class ElasticsearchStorage(ExtractedInformationStorage):
                     # save old version into index_archive
                     old_version = request['hits']['hits'][0]
                     old_version['_source']['descendent'] = True
-                    self.es.index(index=self.index_archive, doc_type='article', body=old_version['_source'])
+                    self.es.index(index=self.index_archive, doc_type='_doc', body=old_version['_source'])
                     version += 1
                     ancestor = old_version['_id']
 
@@ -488,7 +488,7 @@ class ElasticsearchStorage(ExtractedInformationStorage):
                 extracted_info = ExtractedInformationStorage.extract_relevant_info(item)
                 extracted_info['ancestor'] = ancestor
                 extracted_info['version'] = version
-                self.es.index(index=self.index_current, doc_type='article', id=ancestor,
+                self.es.index(index=self.index_current, doc_type='_doc', id=ancestor,
                               body=extracted_info)
 
 


### PR DESCRIPTION
Hi,
I've noticed an error when tried to work with Elasticsearch 6.6.1:
1. mapping is not compatible to the new versions of ES - corrected the mapping
2. theres is not type anymore in ES indices - change the doc type to the defualt.

Thanks,
Eynan