### PR TITLE
Avoid compiling regexes each iteration

### DIFF
--- a/newsplease/crawler/spiders/gdelt_crawler.py
+++ b/newsplease/crawler/spiders/gdelt_crawler.py
@@ -9,6 +9,7 @@ import re
 import requests, zipfile, io
 import csv
 import os
+re_export = re.compile(r'.*?(http.*?export\.CSV\.zip)')
 
 
 class GdeltCrawler(scrapy.Spider):
@@ -51,7 +52,7 @@ class GdeltCrawler(scrapy.Spider):
         :param obj response: The scrapy response
         """
         # get last_update zip url
-        match = re.match(r'.*?(http.*?export\.CSV\.zip)', response.text)
+        match = re.match(re_export, response.text)
         if match:
             last_update_zip_url = match.group(1)
             # fetch zip file

--- a/newsplease/crawler/spiders/rss_crawler.py
+++ b/newsplease/crawler/spiders/rss_crawler.py
@@ -7,6 +7,11 @@ import re
 
 import scrapy
 
+re_rss = re.compile(
+    r'(<link[^>]*href[^>]*type ?= ?"application\/rss\+xml"|' +
+    r'<link[^>]*type ?= ?"application\/rss\+xml"[^>]*href)'
+)
+
 
 class RssCrawler(scrapy.Spider):
     name = "RssCrawler"
@@ -93,7 +98,4 @@ class RssCrawler(scrapy.Spider):
         response = urllib2.urlopen(redirect).read()
 
         # Check if a standard rss feed exists
-        return re.search(
-            r'(<link[^>]*href[^>]*type ?= ?"application\/rss\+xml"|' +
-            r'<link[^>]*type ?= ?"application\/rss\+xml"[^>]*href)',
-            response.decode('utf-8')) is not None
+        return re.search(re_rss, response.decode('utf-8')) is not None

--- a/newsplease/helper_classes/heuristics.py
+++ b/newsplease/helper_classes/heuristics.py
@@ -6,6 +6,8 @@ import re
 from .sub_classes.heuristics_manager import HeuristicsManager
 from .url_extractor import UrlExtractor
 
+re_url_root = re.compile(r'https?://[a-z]+.')
+
 
 class Heuristics(HeuristicsManager):
     """
@@ -126,5 +128,5 @@ class Heuristics(HeuristicsManager):
         :return bool: Determines if the response's url is from a subdomain
         """
 
-        root_url = re.sub(r'https?://[a-z]+.', '', site_dict["url"])
+        root_url = re.sub(re_url_root, '', site_dict["url"])
         return UrlExtractor.get_allowed_domain(response.url) == root_url

--- a/newsplease/helper_classes/parse_crawler.py
+++ b/newsplease/helper_classes/parse_crawler.py
@@ -9,6 +9,8 @@ import scrapy
 
 from ..crawler.items import NewscrawlerItem
 
+re_html = re.compile('text/html')
+
 
 class ParseCrawler(object):
     """
@@ -99,12 +101,14 @@ class ParseCrawler(object):
         # Recursivly crawl all URLs on the current page
         # that do not point to irrelevant file types
         # or contain any of the given ignore_regex regexes
-        return [scrapy.Request(response.urljoin(href), callback=spider.parse)
-                for href in response.css("a::attr('href')").extract()
-                if re.match(r'.*\.' + ignore_file_extensions + r'$',
-                            response.urljoin(href), re.IGNORECASE) is None and
-                len(re.match(ignore_regex,
-                             response.urljoin(href)).group(0)) == 0]
+        return [
+            scrapy.Request(response.urljoin(href), callback=spider.parse)
+            for href in response.css("a::attr('href')").extract() if re.match(
+                r'.*\.' + ignore_file_extensions +
+                r'$', response.urljoin(href), re.IGNORECASE
+            ) is None
+            and len(re.match(ignore_regex, response.urljoin(href)).group(0)) == 0
+        ]
 
     def content_type(self, response):
         """
@@ -113,10 +117,11 @@ class ParseCrawler(object):
         :param obj response: The scrapy response
         :return bool: Determines wether the response is of the correct type
         """
-        if not re.match('text/html', response.headers.get('Content-Type').decode('utf-8')):
-            self.log.warn("Dropped: %s's content is not of type "
-                          "text/html but %s", response.url,
-                          response.headers.get('Content-Type'))
+        if not re_html.match(response.headers.get('Content-Type').decode('utf-8')):
+            self.log.warn(
+                "Dropped: %s's content is not of type "
+                "text/html but %s", response.url, response.headers.get('Content-Type')
+            )
             return False
         else:
             return True

--- a/newsplease/helper_classes/savepath_parser.py
+++ b/newsplease/helper_classes/savepath_parser.py
@@ -10,6 +10,29 @@ import os
 
 from .url_extractor import UrlExtractor
 
+re_time_exec = re.compile(r'%time_execution\(([^\)]+)\)')
+re_timestamp_exec = re.compile(r'%timestamp_execution')
+
+re_working_path = re.compile(r'%working_path')
+re_time_dl = re.compile(r'%time_download\(([^\)]+)\)')
+re_timstamp_dl = re.compile(r'%timestamp_download')
+re_domain = re.compile(r'%domain\(([^\)]+)\)')
+re_appendmd5_domain = re.compile(r'%appendmd5_domain\(([^\)]+)\)')
+re_md5_domain = re.compile(r'%md5_domain\(([^\)]+)\)')
+re_full_domain = re.compile(r'%full_domain\(([^\)]+)\)')
+re_appendmd5_full_domain = re.compile(r'%appendmd5_full_domain\(([^\)]+)\)')
+re_md5_full_domain = re.compile(r'%md5_full_domain\(([^\)]+)\)')
+re_subdomains = re.compile(r'%subdomains\(([^\)]+)\)')
+re_appendmd5_subdomains = re.compile(r'%appendmd5_subdomains\(([^\)]+)\)')
+re_md5_subdomains = re.compile(r'%md5_subdomains\(([^\)]+)\)')
+re_url_dir = re.compile(r'%url_directory_string\(([^\)]+)\)')
+re_appendmd5_url_dir = re.compile(r'%appendmd5_url_directory_string\(([^\)]+)\)')
+re_md5_url_dir = re.compile(r'%md5_url_directory_string\(([^\)]+)\)')
+re_url_file = re.compile(r'%url_file_name\(([^\)]+)\)')
+re_md5_url_file = re.compile(r'%md5_url_file_name\(([^\)]+)\)')
+re_max_url_file = re.compile(r'%max_url_file_name')
+re_appendmd5_max_url_file = re.compile(r'%appendmd5_max_url_file_name')
+
 
 class SavepathParser(object):
     """
@@ -97,84 +120,97 @@ class SavepathParser(object):
             savepath = self.cfg_savepath
 
         # lambda is used for lazy evaluation
-        savepath = re.sub(r'%working_path',
-                          lambda match: self.working_path, savepath)
+        savepath = re.sub(re_working_path, lambda match: self.working_path, savepath)
 
-        savepath = re.sub(r'%time_download\(([^\)]+)\)',
-                          lambda match: SavepathParser.time_replacer(
-                              match, timestamp), savepath)
-        savepath = re.sub(r'%timestamp_download', str(timestamp), savepath)
+        savepath = re.sub(
+            re_time_dl, lambda match: SavepathParser.time_replacer(match, timestamp),
+            savepath
+        )
+        savepath = re.sub(re_timstamp_dl, str(timestamp), savepath)
 
-        savepath = re.sub(r'%domain\(([^\)]+)\)',
-                          lambda match: UrlExtractor
-                          .get_allowed_domain(url, False)[
-                                        :int(match.group(1))], savepath)
-        savepath = re.sub(r'%appendmd5_domain\(([^\)]+)\)',
-                          lambda match: SavepathParser.append_md5_if_too_long(
-                              UrlExtractor.get_allowed_domain(url, False),
-                              int(match.group(1))), savepath)
-        savepath = re.sub(r'%md5_domain\(([^\)]+)\)',
-                          lambda match: hashlib.md5(
-                              UrlExtractor.get_allowed_domain(url, False).encode('utf-8'))
-                          .hexdigest()[:int(match.group(1))], savepath)
+        savepath = re.sub(
+            re_domain, lambda match: UrlExtractor.get_allowed_domain(url, False)
+            [:int(match.group(1))], savepath
+        )
+        savepath = re.sub(
+            re_appendmd5_domain, lambda match: SavepathParser.append_md5_if_too_long(
+                UrlExtractor.get_allowed_domain(url, False), int(match.group(1))
+            ), savepath
+        )
+        savepath = re.sub(
+            re_md5_domain, lambda match: hashlib.md5(
+                UrlExtractor.get_allowed_domain(url, False).encode('utf-8')
+            ).hexdigest()[:int(match.group(1))], savepath
+        )
 
-        savepath = re.sub(r'%full_domain\(([^\)]+)\)',
-                          lambda match: UrlExtractor.get_allowed_domain(url)[
-                                        :int(match.group(1))], savepath)
-        savepath = re.sub(r'%appendmd5_full_domain\(([^\)]+)\)',
-                          lambda match: SavepathParser.append_md5_if_too_long(
-                              UrlExtractor.get_allowed_domain(url),
-                              int(match.group(1))), savepath)
-        savepath = re.sub(r'%md5_full_domain\(([^\)]+)\)',
-                          lambda match: hashlib.md5(
-                              UrlExtractor.get_allowed_domain(url).encode('utf-8'))
-                          .hexdigest()[:int(match.group(1))], savepath)
+        savepath = re.sub(
+            re_full_domain, lambda match: UrlExtractor.get_allowed_domain(url)
+            [:int(match.group(1))], savepath
+        )
+        savepath = re.sub(
+            re_appendmd5_full_domain, lambda match: SavepathParser.append_md5_if_too_long(
+                UrlExtractor.get_allowed_domain(url), int(match.group(1))
+            ), savepath
+        )
+        savepath = re.sub(
+            re_md5_full_domain, lambda match: hashlib.md5(
+                UrlExtractor.get_allowed_domain(url).encode('utf-8')
+            ).hexdigest()[:int(match.group(1))], savepath
+        )
 
-        savepath = re.sub(r'%subdomains\(([^\)]+)\)',
-                          lambda match: UrlExtractor.get_subdomain(url)[
-                                        :int(match.group(1))], savepath)
-        savepath = re.sub(r'%appendmd5_subdomains\(([^\)]+)\)',
-                          lambda match: SavepathParser.append_md5_if_too_long(
-                              UrlExtractor.get_subdomain(url),
-                              int(match.group(1))), savepath)
-        savepath = re.sub(r'%md5_subdomains\(([^\)]+)\)',
-                          lambda match: hashlib.md5(
-                              UrlExtractor.get_subdomain(url).encode('utf-8'))
-                          .hexdigest()[:int(match.group(1))], savepath)
+        savepath = re.sub(
+            re_subdomains, lambda match: UrlExtractor.get_subdomain(url)
+            [:int(match.group(1))], savepath
+        )
+        savepath = re.sub(
+            re_appendmd5_subdomains, lambda match: SavepathParser.
+            append_md5_if_too_long(UrlExtractor.get_subdomain(url), int(match.group(1))),
+            savepath
+        )
+        savepath = re.sub(
+            re_md5_subdomains, lambda match: hashlib.md5(
+                UrlExtractor.get_subdomain(url).encode('utf-8')
+            ).hexdigest()[:int(match.group(1))], savepath
+        )
 
-        savepath = re.sub(r'%url_directory_string\(([^\)]+)\)',
-                          lambda match: UrlExtractor
-                          .get_url_directory_string(url)[:int(match.group(1))],
-                          savepath)
-        savepath = re.sub(r'%appendmd5_url_directory_string\(([^\)]+)\)',
-                          lambda match: SavepathParser.append_md5_if_too_long(
-                              UrlExtractor.get_url_directory_string(url),
-                              int(match.group(1))), savepath)
-        savepath = re.sub(r'%md5_url_directory_string\(([^\)]+)\)',
-                          lambda match: hashlib.md5(
-                              UrlExtractor.get_url_directory_string(url).encode('utf-8'))
-                          .hexdigest()[:int(match.group(1))], savepath)
+        savepath = re.sub(
+            re_url_dir, lambda match: UrlExtractor.get_url_directory_string(url)
+            [:int(match.group(1))], savepath
+        )
+        savepath = re.sub(
+            re_appendmd5_url_dir, lambda match: SavepathParser.append_md5_if_too_long(
+                UrlExtractor.get_url_directory_string(url), int(match.group(1))
+            ), savepath
+        )
+        savepath = re.sub(
+            re_md5_url_dir, lambda match: hashlib.md5(
+                UrlExtractor.get_url_directory_string(url).encode('utf-8')
+            ).hexdigest()[:int(match.group(1))], savepath
+        )
 
-        savepath = re.sub(r'%url_file_name\(([^\)]+)\)',
-                          lambda match: UrlExtractor
-                          .get_url_file_name(url)[:int(match.group(1))],
-                          savepath)
-        savepath = re.sub(r'%md5_url_file_name\(([^\)]+)\)',
-                          lambda match: hashlib.md5(
-                              UrlExtractor.get_url_file_name(url).encode('utf-8'))
-                          .hexdigest()[:int(match.group(1))], savepath)
+        savepath = re.sub(
+            re_url_file, lambda match: UrlExtractor.get_url_file_name(url)
+            [:int(match.group(1))], savepath
+        )
+        savepath = re.sub(
+            re_md5_url_file, lambda match: hashlib.md5(
+                UrlExtractor.get_url_file_name(url).encode('utf-8')
+            ).hexdigest()[:int(match.group(1))], savepath
+        )
 
         abs_savepath = self.get_abs_path(savepath)
 
-        savepath = re.sub(r'%max_url_file_name',
-                          lambda match: UrlExtractor.get_url_file_name(url)[
-                                        :SavepathParser.get_max_url_file_name_length(
-                                            abs_savepath)], savepath)
-        savepath = re.sub(r'%appendmd5_max_url_file_name',
-                          lambda match: SavepathParser.append_md5_if_too_long(
-                              UrlExtractor.get_url_file_name(url),
-                              SavepathParser.get_max_url_file_name_length(
-                                  abs_savepath)), savepath)
+        savepath = re.sub(
+            re_max_url_file, lambda match: UrlExtractor.get_url_file_name(url)
+            [:SavepathParser.get_max_url_file_name_length(abs_savepath)], savepath
+        )
+        savepath = re.sub(
+            re_appendmd5_max_url_file, lambda match: SavepathParser.
+            append_md5_if_too_long(
+                UrlExtractor.get_url_file_name(url),
+                SavepathParser.get_max_url_file_name_length(abs_savepath)
+            ), savepath
+        )
 
         # ensure the savepath doesn't contain any invalid characters
         return SavepathParser.remove_not_allowed_chars(savepath)

--- a/newsplease/helper_classes/url_extractor.py
+++ b/newsplease/helper_classes/url_extractor.py
@@ -20,6 +20,9 @@ except ImportError:
 # len(".markdown") = 9
 MAX_FILE_EXTENSION_LENGTH = 9
 
+re_www = re.compile(r'^(www.)')
+re_domain = re.compile(r'[^/.]+\.[^/.]+$', )
+
 
 class UrlExtractor(object):
     """
@@ -36,11 +39,9 @@ class UrlExtractor(object):
         :return str: subdomains.domain.topleveldomain or domain.topleveldomain
         """
         if allow_subdomains:
-            return re.sub(r'^(www.)',
-                          '', re.search(r'[^/]+\.[^/]+', url).group(0))
+            return re.sub(re_www, '', re.search(r'[^/]+\.[^/]+', url).group(0))
         else:
-            return re.search(r'[^/.]+\.[^/.]+$',
-                             UrlExtractor.get_allowed_domain(url)).group(0)
+            return re.search(re_domain, UrlExtractor.get_allowed_domain(url)).group(0)
 
     @staticmethod
     def get_subdomain(url):

--- a/newsplease/pipeline/extractor/cleaner.py
+++ b/newsplease/pipeline/extractor/cleaner.py
@@ -4,6 +4,12 @@ import sys
 
 from lxml import html
 
+rex1 = re.compile(r'(?<=\n)( )+')
+rex2 = re.compile(r'^[ \t\n\r\f]*')
+rex3 = re.compile(r'[ \t]+(?=([ \t]))')
+rex4 = re.compile(r'[ \n]+(?=(\n))')
+rex5 = re.compile(r'[ \n]*$')
+
 
 class Cleaner:
     """The Cleaner-Class tries to get the raw extracted text of the extractors
@@ -32,15 +38,15 @@ class Cleaner:
         :return: A string, the cleaned string
         """
         # Deletes whitespaces after a newline
-        arg = re.sub(r'(?<=\n)( )+', '', arg)
+        arg = re.sub(rex1, '', arg)
         # Deletes every whitespace, tabulator, newline at the beginning of the string
-        arg = re.sub(r'^[ \t\n\r\f]*', '', arg)
+        arg = re.sub(rex2, '', arg)
         # Deletes whitespace or tabulator if followed by whitespace or tabulator
-        arg = re.sub(r'[ \t]+(?=([ \t]))', '', arg)
+        arg = re.sub(rex3, '', arg)
         #  Deletes newline if it is followed by an other one
-        arg = re.sub(r'[ \n]+(?=(\n))', '', arg)
+        arg = re.sub(rex4, '', arg)
         # Deletes newlines and whitespaces at the end of the string
-        arg = re.sub(r'[ \n]*$', '', arg)
+        arg = re.sub(rex5, '', arg)
         return arg
 
     def do_cleaning(self, arg):

--- a/newsplease/pipeline/extractor/cleaner.py
+++ b/newsplease/pipeline/extractor/cleaner.py
@@ -4,11 +4,11 @@ import sys
 
 from lxml import html
 
-rex1 = re.compile(r'(?<=\n)( )+')
-rex2 = re.compile(r'^[ \t\n\r\f]*')
-rex3 = re.compile(r'[ \t]+(?=([ \t]))')
-rex4 = re.compile(r'[ \n]+(?=(\n))')
-rex5 = re.compile(r'[ \n]*$')
+re_newline_spc = re.compile(r'(?<=\n)( )+')
+re_starting_whitespc = re.compile(r'^[ \t\n\r\f]*')
+re_multi_spc_tab = re.compile(r'[ \t]+(?=([ \t]))')
+re_double_newline = re.compile(r'[ \n]+(?=(\n))')
+re_ending_spc_newline = re.compile(r'[ \n]*$')
 
 
 class Cleaner:
@@ -38,15 +38,15 @@ class Cleaner:
         :return: A string, the cleaned string
         """
         # Deletes whitespaces after a newline
-        arg = re.sub(rex1, '', arg)
+        arg = re.sub(re_newline_spc, '', arg)
         # Deletes every whitespace, tabulator, newline at the beginning of the string
-        arg = re.sub(rex2, '', arg)
+        arg = re.sub(re_starting_whitespc, '', arg)
         # Deletes whitespace or tabulator if followed by whitespace or tabulator
-        arg = re.sub(rex3, '', arg)
+        arg = re.sub(re_multi_spc_tab, '', arg)
         #  Deletes newline if it is followed by an other one
-        arg = re.sub(rex4, '', arg)
+        arg = re.sub(re_double_newline, '', arg)
         # Deletes newlines and whitespaces at the end of the string
-        arg = re.sub(rex5, '', arg)
+        arg = re.sub(re_ending_spc_newline, '', arg)
         return arg
 
     def do_cleaning(self, arg):

--- a/newsplease/pipeline/extractor/comparer/comparer_topimage.py
+++ b/newsplease/pipeline/extractor/comparer/comparer_topimage.py
@@ -5,6 +5,8 @@ try:
 except ImportError:
     from urllib.parse import urljoin
 
+re_http = re.compile('http://*')
+
 
 class ComparerTopimage():
     """This class compares the topimages of the list of ArticleCandidates and sends the result back to the Comparer."""
@@ -40,7 +42,7 @@ class ComparerTopimage():
     def image_absoulte_path(self, url, image):
         """if the image url does not start with 'http://' it will take the absolute path from the url
         and fuses them with urljoin"""
-        if not re.match('http://*', image):
+        if not re.match(re_http, image):
             topimage = urljoin(url, image)
             return topimage
         return image

--- a/newsplease/pipeline/extractor/extractors/date_extractor.py
+++ b/newsplease/pipeline/extractor/extractors/date_extractor.py
@@ -12,6 +12,11 @@ try:
 except ImportError:
     import urllib2
 
+re_pub_date = re.compile(
+    r'([\./\-_]{0,1}(19|20)\d{2})[\./\-_]{0,1}(([0-3]{0,1}[0-9][\./\-_])|(\w{3,5}[\./\-_]))([0-3]{0,1}[0-9][\./\-]{0,1})?'
+)
+re_class = re.compile("pubdate|timestamp|article_date|articledate|date", re.IGNORECASE)
+
 
 class DateExtractor(AbstractExtractor):
     """This class implements ArticleDateExtractor as an article extractor. ArticleDateExtractor is
@@ -62,9 +67,7 @@ class DateExtractor(AbstractExtractor):
         """Try to extract from the article URL - simple but might work as a fallback"""
 
         # Regex by Newspaper3k  - https://github.com/codelucas/newspaper/blob/master/newspaper/urls.py
-        m = re.search(
-            r'([\./\-_]{0,1}(19|20)\d{2})[\./\-_]{0,1}(([0-3]{0,1}[0-9][\./\-_])|(\w{3,5}[\./\-_]))([0-3]{0,1}[0-9][\./\-]{0,1})?',
-            url)
+        m = re.search(re_pub_date, url)
         if m:
             return self.parse_date_str(m.group(0))
         return None
@@ -216,8 +219,7 @@ class DateExtractor(AbstractExtractor):
                 return self.parse_date_str(date_string)
 
         # class=
-        for tag in html.find_all(['span', 'p', 'div'],
-                                 class_=re.compile("pubdate|timestamp|article_date|articledate|date", re.IGNORECASE)):
+        for tag in html.find_all(['span', 'p', 'div'], class_=re_class):
             date_string = tag.string
             if date_string is None:
                 date_string = tag.text


### PR DESCRIPTION
To improve speed/efficiency

Regular expressions are cached (https://docs.python.org/3/library/re.html#re.compile) but only 100 at a time; since there some regexes that are dynamic and must be compiled each loop there is regex cache thrashing thus this commit should improve speed.