### PR TITLE
solve issue #107 (TypeError: not iterable)

### DIFF
--- a/newsplease/crawler/commoncrawl_extractor.py
+++ b/newsplease/crawler/commoncrawl_extractor.py
@@ -137,8 +137,8 @@ class CommonCrawlExtractor:
         :param warc_record:
         :return:
         """
-        if hasattr(article, 'publish_date'):
-            return parser.parse(article.publish_date)
+        if hasattr(article, 'date_publish'):
+            return parser.parse(article.date_publish)
         else:
             return None
 

--- a/newsplease/crawler/commoncrawl_extractor.py
+++ b/newsplease/crawler/commoncrawl_extractor.py
@@ -138,7 +138,7 @@ class CommonCrawlExtractor:
         :return:
         """
         if hasattr(article, 'date_publish'):
-            return parser.parse(article.date_publish)
+            return parser.parse(article.date_publish) if isinstance(article.date_publish, str) else article.date_publish
         else:
             return None
 

--- a/newsplease/crawler/commoncrawl_extractor.py
+++ b/newsplease/crawler/commoncrawl_extractor.py
@@ -137,7 +137,7 @@ class CommonCrawlExtractor:
         :param warc_record:
         :return:
         """
-        if 'publish_date' in article:
+        if hasattr(article, 'publish_date'):
             return parser.parse(article.publish_date)
         else:
             return None


### PR DESCRIPTION
solve issue #107 (TypeError: argument of type 'NewsArticle' is not iterable)
https://github.com/fhamborg/news-please/issues/107

```bash
Traceback (most recent call last):
  File "/data/anaconda/envs/giga/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/data/anaconda/envs/giga/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/mnt/data/news-please/newsplease/examples/commoncrawl.py", line 169, in <module>
    main()
  File "/mnt/data/news-please/newsplease/examples/commoncrawl.py", line 165, in main
    continue_process=True)
  File "/mnt/data/news-please/newsplease/crawler/commoncrawl_crawler.py", line 297, in crawl_from_commoncrawl
    log_pathname_fully_extracted_warcs=__log_pathname_fully_extracted_warcs)
  File "/mnt/data/news-please/newsplease/crawler/commoncrawl_crawler.py", line 208, in __start_commoncrawl_extractor
    log_pathname_fully_extracted_warcs=__log_pathname_fully_extracted_warcs)
  File "/mnt/data/news-please/newsplease/crawler/commoncrawl_extractor.py", line 338, in extract_from_commoncrawl
    self.__run()
  File "/mnt/data/news-please/newsplease/crawler/commoncrawl_extractor.py", line 292, in __run
    self.__process_warc_gz_file(local_path_name)
  File "/mnt/data/news-please/newsplease/crawler/commoncrawl_extractor.py", line 237, in __process_warc_gz_file
    filter_pass, article = self.__filter_record(record)
  File "/mnt/data/news-please/newsplease/crawler/commoncrawl_extractor.py", line 121, in __filter_record
    publishing_date = self.__get_publishing_date(warc_record, article)
  File "/mnt/data/news-please/newsplease/crawler/commoncrawl_extractor.py", line 140, in __get_publishing_date
    if 'publish_date' in article:
TypeError: argument of type 'NewsArticle' is not iterable
```