### PR TITLE
allow the use of atom rss feeds

### DIFF
--- a/newsplease/crawler/spiders/rss_crawler.py
+++ b/newsplease/crawler/spiders/rss_crawler.py
@@ -9,8 +9,8 @@ import scrapy
 
 # to improve performance, regex statements are compiled only once per module
 re_rss = re.compile(
-    r'(<link[^>]*href[^>]*type ?= ?"application\/rss\+xml"|' +
-    r'<link[^>]*type ?= ?"application\/rss\+xml"[^>]*href)'
+    r'(<*link[^>]*href[^>]*type ?= ?"application\/rss\+xml"|' +
+    r'<*link[^>]*type ?= ?"application\/rss\+xml"[^>]*href)'
 )
 
 


### PR DESCRIPTION
Currently, News-please does not parse atom feeds. This PR fixes that.