### PR TITLE
url_extractor functions use crawler agent header and continue on exceptions

### DIFF
--- a/newsplease/crawler/spiders/rss_crawler.py
+++ b/newsplease/crawler/spiders/rss_crawler.py
@@ -1,3 +1,5 @@
+from newsplease.helper_classes.url_extractor import UrlExtractor
+
 try:
     import urllib2
 except ImportError:
@@ -95,7 +97,9 @@ class RssCrawler(scrapy.Spider):
 
         # Follow redirects
         opener = urllib2.build_opener(urllib2.HTTPRedirectHandler)
+        url = UrlExtractor.url_to_request_with_agent(url)
         redirect = opener.open(url).url
+        redirect = UrlExtractor.url_to_request_with_agent(redirect)
         response = urllib2.urlopen(redirect).read()
 
         # Check if a standard rss feed exists

--- a/newsplease/single_crawler.py
+++ b/newsplease/single_crawler.py
@@ -187,7 +187,14 @@ class SingleCrawler(object):
             if hasattr(current, "supports_site"):
                 supports_site = getattr(current, "supports_site")
                 if callable(supports_site):
-                    if supports_site(url):
+                    try:
+                        crawler_supports_site = supports_site(url)
+                    except Exception as e:
+                        self.log.info(f'Crawler not supported due to: {str(e)}',
+                                      exc_info=True)
+                        crawler_supports_site = False
+
+                    if crawler_supports_site:
                         self.log.debug("Using crawler %s for %s.",
                                        crawler, url)
                         return current


### PR DESCRIPTION
The url_extractor functions that do request now use the user-agent header that is configured

Since there still might happen exceptions like a http forbidden, these are catched during the `supports_site` check