### PR TITLE
Updates from_url return type docs

### DIFF
--- a/newsplease/__init__.py
+++ b/newsplease/__init__.py
@@ -88,7 +88,8 @@ class NewsPlease:
         Crawls the article from the url and extracts relevant information.
         :param url:
         :param timeout: in seconds, if None, the urllib default is used
-        :return: A dict containing all the information of the article. Else, None.
+        :return: A NewsArticle object containing all the information of the article. Else, None.
+        :rtype: NewsArticle, None
         """
         articles = NewsPlease.from_urls([url], timeout=timeout)
         if url in articles.keys():


### PR DESCRIPTION
This is a really simple change; I just noticed that `from_url` was documented as returning a `dict` when it actually returns a `NewsArticle` object. I'm not super familiar with Sphinx docstrings so let me know if there are ways to make this more clear.