### PR TITLE
Stopped the LOG_ENABLED variable from being unset

### DIFF
--- a/newsplease/config.py
+++ b/newsplease/config.py
@@ -153,9 +153,6 @@ class CrawlerConfig(object):
 
         configure_logging(self.get_scrapy_options())
 
-        # Disable duplicates
-        self.__scrapy_options["LOG_ENABLED"] = False
-
         # Now, after log-level is correctly set, lets log them.
         for msg in self.log_output:
             if msg["level"] is "error":


### PR DESCRIPTION
The LOG_ENABLED variable is not honored in the spider (using RecursiveSpider) because it's being unset here.