### PR TITLE
add date filter for commoncrawl warc files

### DIFF
--- a/newsplease/crawler/commoncrawl_crawler.py
+++ b/newsplease/crawler/commoncrawl_crawler.py
@@ -117,7 +117,11 @@ def __get_remote_index(warc_files_start_date):
             month = date.strftime('%m')
             cmd += "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/%s/%s/ --no-sign-request >> .tmpaws.txt && " %(year, month)
 
-    cmd += "awk '{ print $4 }' .tmpaws.txt && " \
+        cmd += "awk '{ print $4 }' .tmpaws.txt && " \
+              "rm .tmpaws.txt"
+    else:
+        cmd = "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/ --no-sign-request > .tmpaws.txt && " \
+          "awk '{ print $4 }' .tmpaws.txt && " \
           "rm .tmpaws.txt"
     __logger.info('executing: %s', cmd)
     stdout_data = subprocess.getoutput(cmd)

--- a/newsplease/crawler/commoncrawl_crawler.py
+++ b/newsplease/crawler/commoncrawl_crawler.py
@@ -10,6 +10,7 @@ import subprocess
 import time
 from functools import partial
 from multiprocessing import Pool
+import datetime
 
 from dateutil import parser
 from scrapy.utils.log import configure_logging
@@ -89,8 +90,17 @@ def __get_download_url(name):
     """
     return __cc_base_url + name
 
+def __iterate_by_month(start_date, end_date, month_step=1):
+    current_date = start_date
+    while current_date < end_date:
+        yield current_date
+        carry, new_month = divmod(current_date.month - 1 + month_step, 12)
+        new_month += 1
+        current_date = current_date.replace(year=current_date.year + carry,
+                                            month=new_month)
 
-def __get_remote_index():
+
+def __get_remote_index(warc_files_start_date):
     """
     Gets the index of news crawl files from commoncrawl.org and returns an array of names
     :return:
@@ -98,8 +108,16 @@ def __get_remote_index():
     # cleanup
     subprocess.getoutput("rm tmpaws.txt")
     # get the remote info
-    cmd = "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/ --no-sign-request > .tmpaws.txt && " \
-          "awk '{ print $4 }' .tmpaws.txt && " \
+
+    cmd = ''
+    if warc_files_start_date:
+        warc_dates = __iterate_by_month(warc_files_start_date, datetime.datetime.today())
+        for date in warc_dates:
+            year = date.strftime('%Y')
+            month = date.strftime('%m')
+            cmd += "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/%s/%s/ --no-sign-request >> .tmpaws.txt && " %(year, month)
+
+    cmd += "awk '{ print $4 }' .tmpaws.txt && " \
           "rm .tmpaws.txt"
     __logger.info('executing: %s', cmd)
     stdout_data = subprocess.getoutput(cmd)
@@ -169,7 +187,7 @@ def __callback_on_warc_completed(warc_path, counter_article_passed, counter_arti
 
 def __start_commoncrawl_extractor(warc_download_url, callback_on_article_extracted=None,
                                   callback_on_warc_completed=None, valid_hosts=None,
-                                  start_date=None, end_date=None,
+                                  start_date=None, end_date=None, 
                                   strict_date=True, reuse_previously_downloaded_files=True,
                                   local_download_dir_warc=None,
                                   continue_after_error=True, show_download_progress=False,
@@ -209,8 +227,9 @@ def __start_commoncrawl_extractor(warc_download_url, callback_on_article_extract
 
 
 def crawl_from_commoncrawl(callback_on_article_extracted, callback_on_warc_completed=None, valid_hosts=None,
-                           start_date=None, end_date=None, strict_date=True, reuse_previously_downloaded_files=True,
-                           local_download_dir_warc=None, continue_after_error=True, show_download_progress=False,
+                           start_date=None, end_date=None, warc_files_start_date=None, strict_date=True, 
+                           reuse_previously_downloaded_files=True, local_download_dir_warc=None, 
+                           continue_after_error=True, show_download_progress=False,
                            number_of_extraction_processes=4, log_level=logging.ERROR,
                            delete_warc_after_extraction=True, continue_process=True):
     """
@@ -237,7 +256,7 @@ def crawl_from_commoncrawl(callback_on_article_extracted, callback_on_warc_compl
     global __extern_callback_on_warc_completed
     __extern_callback_on_warc_completed = callback_on_warc_completed
 
-    cc_news_crawl_names = __get_remote_index()
+    cc_news_crawl_names = __get_remote_index(warc_files_start_date)
     global __number_of_warc_files_on_cc
     __number_of_warc_files_on_cc = len(cc_news_crawl_names)
     __logger.info('found %i files at commoncrawl.org', __number_of_warc_files_on_cc)

--- a/newsplease/examples/commoncrawl.py
+++ b/newsplease/examples/commoncrawl.py
@@ -24,6 +24,8 @@ import json
 import logging
 import os
 import sys
+import datetime
+from datetime import date
 
 from ..crawler import commoncrawl_crawler as commoncrawl_crawler
 
@@ -34,16 +36,17 @@ __credits__ = ["Sebastian Nagel"]
 
 ############ YOUR CONFIG ############
 # download dir for warc files
-my_local_download_dir_warc = './cc_download_warc/'
+my_local_download_dir_warc = './cc_download_warc_test/'
 # download dir for articles
-my_local_download_dir_article = './cc_download_articles/'
+my_local_download_dir_article = './cc_download_articles_march_april_2020_test/'
 # hosts (if None or empty list, any host is OK)
 my_filter_valid_hosts = []  # example: ['elrancaguino.cl']
 # start date (if None, any date is OK as start date), as datetime
-my_filter_start_date = None  # datetime.datetime(2016, 1, 1)
+my_filter_start_date = datetime.datetime(2020, 3, 1)  # datetime.datetime(2016, 1, 1)
 # end date (if None, any date is OK as end date), as datetime
-my_filter_end_date = None  # datetime.datetime(2016, 12, 31)
+my_filter_end_date = datetime.datetime(2020, 4, 24)  # datetime.datetime(2016, 12, 31)
 # if date filtering is strict and news-please could not detect the date of an article, the article will be discarded
+my_warc_files_start_date = datetime.datetime(2020, 3, 1)
 my_filter_strict_date = True
 # if True, the script checks whether a file has been downloaded already and uses that file instead of downloading
 # again. Note that there is no check whether the file has been downloaded completely or is valid!
@@ -51,13 +54,13 @@ my_reuse_previously_downloaded_files = True
 # continue after error
 my_continue_after_error = True
 # show the progress of downloading the WARC files
-my_show_download_progress = False
+my_show_download_progress = True
 # log_level
 my_log_level = logging.INFO
 # json export style
 my_json_export_style = 1  # 0 (minimize), 1 (pretty)
 # number of extraction processes
-my_number_of_extraction_processes = 1
+my_number_of_extraction_processes = 16
 # if True, the WARC file will be deleted after all articles have been extracted from it
 my_delete_warc_after_extraction = True
 # if True, will continue extraction from the latest fully downloaded but not fully extracted WARC files and then
@@ -126,6 +129,15 @@ def callback_on_warc_completed(warc_path, counter_article_passed, counter_articl
     """
     pass
 
+def iterate_by_month(start_date, end_date, month_step=1):
+    current_date = start_date
+    while current_date < end_date:
+        yield current_date
+        carry, new_month = divmod(current_date.month - 1 + month_step, 12)
+        new_month += 1
+        current_date = current_date.replace(year=current_date.year + carry,
+                                            month=new_month)
+
 
 def main():
     global my_local_download_dir_warc
@@ -153,6 +165,7 @@ def main():
                                                valid_hosts=my_filter_valid_hosts,
                                                start_date=my_filter_start_date,
                                                end_date=my_filter_end_date,
+                                               warc_files_start_date=my_warc_files_start_date,
                                                strict_date=my_filter_strict_date,
                                                reuse_previously_downloaded_files=my_reuse_previously_downloaded_files,
                                                local_download_dir_warc=my_local_download_dir_warc,

--- a/newsplease/examples/commoncrawl.py
+++ b/newsplease/examples/commoncrawl.py
@@ -36,17 +36,17 @@ __credits__ = ["Sebastian Nagel"]
 
 ############ YOUR CONFIG ############
 # download dir for warc files
-my_local_download_dir_warc = './cc_download_warc_test/'
+my_local_download_dir_warc = './cc_download_warc/'
 # download dir for articles
-my_local_download_dir_article = './cc_download_articles_march_april_2020_test/'
+my_local_download_dir_article = './cc_download_articles/'
 # hosts (if None or empty list, any host is OK)
 my_filter_valid_hosts = []  # example: ['elrancaguino.cl']
 # start date (if None, any date is OK as start date), as datetime
-my_filter_start_date = datetime.datetime(2020, 3, 1)  # datetime.datetime(2016, 1, 1)
+my_filter_start_date = None  # datetime.datetime(2016, 1, 1)
 # end date (if None, any date is OK as end date), as datetime
-my_filter_end_date = datetime.datetime(2020, 4, 24)  # datetime.datetime(2016, 12, 31)
+my_filter_end_date = None  # datetime.datetime(2016, 12, 31)
 # if date filtering is strict and news-please could not detect the date of an article, the article will be discarded
-my_warc_files_start_date = datetime.datetime(2020, 3, 1)
+my_warc_files_start_date = None # example: datetime.datetime(2020, 3, 1)
 my_filter_strict_date = True
 # if True, the script checks whether a file has been downloaded already and uses that file instead of downloading
 # again. Note that there is no check whether the file has been downloaded completely or is valid!
@@ -54,13 +54,13 @@ my_reuse_previously_downloaded_files = True
 # continue after error
 my_continue_after_error = True
 # show the progress of downloading the WARC files
-my_show_download_progress = True
+my_show_download_progress = False
 # log_level
 my_log_level = logging.INFO
 # json export style
 my_json_export_style = 1  # 0 (minimize), 1 (pretty)
 # number of extraction processes
-my_number_of_extraction_processes = 16
+my_number_of_extraction_processes = 1
 # if True, the WARC file will be deleted after all articles have been extracted from it
 my_delete_warc_after_extraction = True
 # if True, will continue extraction from the latest fully downloaded but not fully extracted WARC files and then
@@ -128,15 +128,6 @@ def callback_on_warc_completed(warc_path, counter_article_passed, counter_articl
     :return:
     """
     pass
-
-def iterate_by_month(start_date, end_date, month_step=1):
-    current_date = start_date
-    while current_date < end_date:
-        yield current_date
-        carry, new_month = divmod(current_date.month - 1 + month_step, 12)
-        new_month += 1
-        current_date = current_date.replace(year=current_date.year + carry,
-                                            month=new_month)
 
 
 def main():


### PR DESCRIPTION
I created a change related to this issue: https://github.com/fhamborg/news-please/issues/142, please see issue for details.

I was encountering the same issue and decided to make the change. I added the change in the __get_remote_index function where I limit warc files to download based on the date folders they are in on s3. 

I added a new parameter `warc_files_start_date`, instead of using the start_date, because I noticed that a few files could be in earlier warc files, but the majority is after the warc file date. It is still worthwhile to have this filter because it saves a lot of time.