### PR TITLE
Fixed broken date extraction due to beautiful soup's tag.text.

### DIFF
--- a/newsplease/pipeline/extractor/extractors/date_extractor.py
+++ b/newsplease/pipeline/extractor/extractors/date_extractor.py
@@ -80,7 +80,7 @@ class DateExtractor(AbstractExtractor):
             if script is None:
                 return None
 
-            data = json.loads(script.text)
+            data = json.loads(script.string)
 
             try:
                 date = self.parse_date_str(data['datePublished'])


### PR DESCRIPTION
Date extraction fails because tag.text returns an empty string in the date extractor.

Replaced tag.text with tag.string as the solution.

Documentation pertaining to accessing text inside a tag.
https://www.crummy.com/software/BeautifulSoup/bs4/doc/#string
