### PR TITLE
Windows Compatability and Subprocess Check

### DIFF
--- a/newsplease/crawler/commoncrawl_crawler.py
+++ b/newsplease/crawler/commoncrawl_crawler.py
@@ -124,7 +124,11 @@ def __get_remote_index(warc_files_start_date):
           "awk '{ print $4 }' .tmpaws.txt && " \
           "rm .tmpaws.txt"
     __logger.info('executing: %s', cmd)
-    stdout_data = subprocess.getoutput(cmd)
+    exitcode, stdout_data = subprocess.getstatusoutput(cmd)
+
+    if exitcode > 0:
+        raise Exception(stdout_data)
+
 
     lines = stdout_data.splitlines()
     return lines


### PR DESCRIPTION
I tried to address the following issues in this pull request:

- Fixes issue #79 : In this issue, the urls are produced via `__get_remote_index` in `newsplease/crawler/commoncrawl_crawler.py.`. The output of the `subprocess` in that method is directly returned. Thus it is considered as a link even though there is an error during the execution of the subprocess. Since the output containing the error message is returned directly to caller methods, it was leading other errors in the code, which was hard to understand the issue. Thus, I tried to add exit-code check to the  `subprocess`. (Of course, it will still complain if `aws-cli` is not installed; however, the error will be clear. I have encountered a similar issue since `awscli-plugin-endpoint` was not installed.
- I realized that `rm` command and single quotations with `awk` command were not compatible with Windows. Thus, I tried to use their equivalents within the Windows universe. 