### PR TITLE
Add exitcode check for Subprocesses

### DIFF
--- a/newsplease/crawler/commoncrawl_crawler.py
+++ b/newsplease/crawler/commoncrawl_crawler.py
@@ -124,7 +124,10 @@ def __get_remote_index(warc_files_start_date):
           "awk '{ print $4 }' .tmpaws.txt && " \
           "rm .tmpaws.txt"
     __logger.info('executing: %s', cmd)
-    stdout_data = subprocess.getoutput(cmd)
+    exitcode, stdout_data = subprocess.getstatusoutput(cmd)
+
+    if exitcode > 0:
+        raise Exception(stdout_data)
 
     lines = stdout_data.splitlines()
     return lines

--- a/newsplease/crawler/commoncrawl_extractor.py
+++ b/newsplease/crawler/commoncrawl_extractor.py
@@ -162,7 +162,11 @@ class CommonCrawlExtractor:
               "awk '{ print $4 }' tmpaws.txt && " \
               "rm tmpaws.txt"
         self.__logger.info('executing: %s', cmd)
-        stdout_data = subprocess.getoutput(cmd)
+        exitcode, stdout_data = subprocess.getstatusoutput(cmd)
+
+        if exitcode > 0:
+            raise Exception(stdout_data)
+
         print(stdout_data)
 
         lines = stdout_data.splitlines()


### PR DESCRIPTION
I tried to address the following issue in this pull request:

Fixes #79 : In this issue, the urls are produced via __get_remote_index in newsplease/crawler/commoncrawl_crawler.py. The output of the subprocess in that method is directly returned. Thus, it is considered as a link even though it is an error message when there is an error during the execution of the subprocess. In this scenario, it leads other errors in the code, which makes hard to understand the actual error. Thus, I tried to add exit-code check to the subprocess. (Of course, it will still complain if aws-cli or awk is not installed; however, the error will be clear. I have encountered a similar issue since awscli-plugin-endpoint was not installed.
