### PR TITLE
Less OS Dependency

### DIFF
--- a/newsplease/crawler/commoncrawl_crawler.py
+++ b/newsplease/crawler/commoncrawl_crawler.py
@@ -105,26 +105,41 @@ def __get_remote_index(warc_files_start_date):
     Gets the index of news crawl files from commoncrawl.org and returns an array of names
     :return:
     """
-    # cleanup
-    subprocess.getoutput("rm tmpaws.txt")
+    temp_filename = ".tmpaws.txt"
+
+    if os.name == 'nt':
+        awk_parameter = '"{ print $4 }"'
+    else:
+        awk_parameter = "'{ print $4 }'"
+
     # get the remote info
 
     cmd = ''
     if warc_files_start_date:
+        # cleanup
+        try:
+            os.remove(temp_filename)
+        except OSError:
+            pass
+
         warc_dates = __iterate_by_month(warc_files_start_date, datetime.datetime.today())
         for date in warc_dates:
             year = date.strftime('%Y')
             month = date.strftime('%m')
-            cmd += "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/%s/%s/ --no-sign-request >> .tmpaws.txt && " %(year, month)
+            cmd += "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/%s/%s/ --no-sign-request >> %s && " % (year, month, temp_filename)
 
-        cmd += "awk '{ print $4 }' .tmpaws.txt && " \
-              "rm .tmpaws.txt"
     else:
-        cmd = "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/ --no-sign-request > .tmpaws.txt && " \
-          "awk '{ print $4 }' .tmpaws.txt && " \
-          "rm .tmpaws.txt"
+        cmd = "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/ --no-sign-request > %s && " % temp_filename
+
+    cmd += "awk %s %s " % (awk_parameter, temp_filename)
+
     __logger.info('executing: %s', cmd)
     stdout_data = subprocess.getoutput(cmd)
+
+    try:
+        os.remove(temp_filename)
+    except OSError:
+        pass
 
     lines = stdout_data.splitlines()
     return lines

--- a/newsplease/crawler/commoncrawl_extractor.py
+++ b/newsplease/crawler/commoncrawl_extractor.py
@@ -155,15 +155,25 @@ class CommonCrawlExtractor:
         Gets the index of news crawl files from commoncrawl.org and returns an array of names
         :return:
         """
-        # cleanup
-        subprocess.getoutput("rm tmpaws.txt")
+        temp_filename = "tmpaws.txt"
+
+        if os.name == 'nt':
+            awk_parameter = '"{ print $4 }"'
+        else:
+            awk_parameter = "'{ print $4 }'"
+
         # get the remote info
-        cmd = "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/ --no-sign-request > tmpaws.txt && " \
-              "awk '{ print $4 }' tmpaws.txt && " \
-              "rm tmpaws.txt"
+        cmd = "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/ --no-sign-request > %s && " \
+              "awk %s %s " % (temp_filename, awk_parameter, temp_filename)
+
         self.__logger.info('executing: %s', cmd)
         stdout_data = subprocess.getoutput(cmd)
         print(stdout_data)
+
+        try:
+            os.remove(temp_filename)
+        except OSError:
+            pass
 
         lines = stdout_data.splitlines()
         return lines


### PR DESCRIPTION
- Since `rm` is not recognized as a command in Windows, I tried to avoid this dependency by replacing it with built-in `os.remove` method. 
- As far as my experience in Windows shows, `awk '{print $4}' filename` does not work in Windows while it works in Linux. However, `awk "{print $4}" filename` works in Windows. I used [gawk for Windows](http://gnuwin32.sourceforge.net/packages/gawk.htm). Thus, I tried to adapt that part of the code based on the operating system on which it's running.
- Additionally I kept removal of the file only before appending to the file (>>). If it is just redirection (>), I did not delete the file in advance.