### PR TITLE
my_delete_warc_after_extraction

### DIFF
--- a/newsplease/examples/commoncrawl.py
+++ b/newsplease/examples/commoncrawl.py
@@ -133,7 +133,7 @@ def callback_on_warc_completed(warc_path, counter_article_passed, counter_articl
 def main():
     global my_local_download_dir_warc
     global my_local_download_dir_article
-    delete_warc_after_extraction = False
+    global my_delete_warc_after_extraction
     global my_number_of_extraction_processes
 
     if len(sys.argv) >= 2:
@@ -141,13 +141,13 @@ def main():
     if len(sys.argv) >= 3:
         my_local_download_dir_article = sys.argv[2]
     if len(sys.argv) >= 4:
-        delete_warc_after_extraction = sys.argv[3] == "delete"
+        my_delete_warc_after_extraction = sys.argv[3] == "delete"
     if len(sys.argv) >= 5:
         my_number_of_extraction_processes = int(sys.argv[4])
 
     print("my_local_download_dir_warc=" + my_local_download_dir_warc)
     print("my_local_download_dir_article=" + my_local_download_dir_article)
-    print("delete_warc_after_extraction=" + str(delete_warc_after_extraction))
+    print("my_delete_warc_after_extraction=" + str(my_delete_warc_after_extraction))
     print("my_number_of_extraction_processes=" + str(my_number_of_extraction_processes))
 
     __setup__()
@@ -164,7 +164,7 @@ def main():
                                                show_download_progress=my_show_download_progress,
                                                number_of_extraction_processes=my_number_of_extraction_processes,
                                                log_level=my_log_level,
-                                               delete_warc_after_extraction=delete_warc_after_extraction,
+                                               delete_warc_after_extraction=my_delete_warc_after_extraction,
                                                continue_process=True)
 
 


### PR DESCRIPTION
`my_delete_warc_after_extraction` within the example configuration was not used actively. I tried to add its (hopefully intended) usage by keeping the command-line logic same as before.