### PR TITLE
Amjltc295/use str html instead of bytes html to speed up

### DIFF
--- a/newsplease/config.py
+++ b/newsplease/config.py
@@ -118,7 +118,7 @@ class CrawlerConfig(object):
                             {"level": "debug",
                              "msg": "Option not literal_eval-parsable"
                                     " (maybe string): [{0}] {1}"
-                                 .format(section, option)})
+                                    .format(section, option)})
 
                     if self.__config[section][option] == -1:
                         self.log_output.append(
@@ -155,11 +155,11 @@ class CrawlerConfig(object):
 
         # Now, after log-level is correctly set, lets log them.
         for msg in self.log_output:
-            if msg["level"] is "error":
+            if msg["level"] == "error":
                 self.log.error(msg["msg"])
-            elif msg["level"] is "info":
+            elif msg["level"] == "info":
                 self.log.info(msg["msg"])
-            elif msg["level"] is "debug":
+            elif msg["level"] == "debug":
                 self.log.debug(msg["msg"])
 
     def config(self):

--- a/newsplease/crawler/response_decoder.py
+++ b/newsplease/crawler/response_decoder.py
@@ -1,0 +1,48 @@
+# Based on https://github.com/adbar/trafilatura/blob/master/trafilatura/utils.py
+import logging
+
+import cchardet  # For unknown encoding, see https://charset-normalizer.readthedocs.io/en/latest/ for more info
+
+logger = logging.getLogger(__name__)
+
+
+def isutf8(data):
+    """Simple heuristic to determine if a bytestring uses standard unicode encoding"""
+    try:
+        data.decode('UTF-8')
+    except UnicodeDecodeError:
+        return False
+    else:
+        return True
+
+
+def detect_encoding(bytesobject):
+    """Read the first chunk of input and return its encoding"""
+    # unicode-test
+    if isutf8(bytesobject):
+        return 'UTF-8'
+    else:
+        guess = cchardet.detect(bytesobject)
+        logger.debug('guessed encoding: %s', guess['encoding'])
+        return guess['encoding']
+    # fallback on full response
+    # if guess is None or guess['encoding'] is None: # or guess['confidence'] < 0.99:
+    #    guessed_encoding = chardet.detect(bytesobject)['encoding']
+    # return
+    return None
+
+
+def decode_response(response):
+    """Read the first chunk of server response and decode it"""
+    guessed_encoding = detect_encoding(response.content)
+    logger.debug('response/guessed encoding: %s / %s', response.encoding, guessed_encoding)
+    # process
+    if guessed_encoding is not None:
+        try:
+            htmltext = response.content.decode(guessed_encoding)
+        except UnicodeDecodeError:
+            logger.warning('encoding error: %s / %s', response.encoding, guessed_encoding)
+            htmltext = response.text
+    else:
+        htmltext = response.text
+    return htmltext

--- a/newsplease/crawler/response_decoder.py
+++ b/newsplease/crawler/response_decoder.py
@@ -3,7 +3,7 @@ import logging
 
 import cchardet  # For unknown encoding, see https://charset-normalizer.readthedocs.io/en/latest/ for more info
 
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 def isutf8(data):
@@ -23,7 +23,7 @@ def detect_encoding(bytesobject):
         return 'UTF-8'
     else:
         guess = cchardet.detect(bytesobject)
-        logger.debug('guessed encoding: %s', guess['encoding'])
+        LOGGER.debug('guessed encoding: %s', guess['encoding'])
         return guess['encoding']
     # fallback on full response
     # if guess is None or guess['encoding'] is None: # or guess['confidence'] < 0.99:
@@ -35,13 +35,13 @@ def detect_encoding(bytesobject):
 def decode_response(response):
     """Read the first chunk of server response and decode it"""
     guessed_encoding = detect_encoding(response.content)
-    logger.debug('response/guessed encoding: %s / %s', response.encoding, guessed_encoding)
+    LOGGER.debug('response/guessed encoding: %s / %s', response.encoding, guessed_encoding)
     # process
     if guessed_encoding is not None:
         try:
             htmltext = response.content.decode(guessed_encoding)
         except UnicodeDecodeError:
-            logger.warning('encoding error: %s / %s', response.encoding, guessed_encoding)
+            LOGGER.warning('encoding error: %s / %s', response.encoding, guessed_encoding)
             htmltext = response.text
     else:
         htmltext = response.text

--- a/newsplease/crawler/simple_crawler.py
+++ b/newsplease/crawler/simple_crawler.py
@@ -11,7 +11,7 @@ from .response_decoder import decode_response
 MAX_FILE_SIZE = 20000000
 MIN_FILE_SIZE = 10
 
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 # customize headers
 HEADERS = {
@@ -50,24 +50,24 @@ class SimpleCrawler(object):
             # so we can stop downloading as soon as MAX_FILE_SIZE is reached
             response = requests.get(url, timeout=timeout, verify=False, allow_redirects=True, headers=HEADERS)
         except (requests.exceptions.MissingSchema, requests.exceptions.InvalidURL):
-            logger.error('malformed URL: %s', url)
+            LOGGER.error('malformed URL: %s', url)
         except requests.exceptions.TooManyRedirects:
-            logger.error('too many redirects: %s', url)
+            LOGGER.error('too many redirects: %s', url)
         except requests.exceptions.SSLError as err:
-            logger.error('SSL: %s %s', url, err)
+            LOGGER.error('SSL: %s %s', url, err)
         except (
             socket.timeout, requests.exceptions.ConnectionError,
             requests.exceptions.Timeout, socket.error, socket.gaierror
         ) as err:
-            logger.error('connection/timeout error: %s %s', url, err)
+            LOGGER.error('connection/timeout error: %s %s', url, err)
         else:
             # safety checks
             if response.status_code != 200:
-                logger.error('not a 200 response: %s', response.status_code)
+                LOGGER.error('not a 200 response: %s', response.status_code)
             elif response.text is None or len(response.text) < MIN_FILE_SIZE:
-                logger.error('too small/incorrect: %s %s', url, len(response.text))
+                LOGGER.error('too small/incorrect: %s %s', url, len(response.text))
             elif len(response.text) > MAX_FILE_SIZE:
-                logger.error('too large: %s %s', url, len(response.text))
+                LOGGER.error('too large: %s %s', url, len(response.text))
             else:
                 html_str = decode_response(response)
         if is_threaded:

--- a/newsplease/crawler/simple_crawler.py
+++ b/newsplease/crawler/simple_crawler.py
@@ -1,7 +1,74 @@
+# Based on https://github.com/adbar/trafilatura/blob/master/trafilatura/utils.py
+import logging
+import socket
 import copy
 import threading
 
-from six.moves import urllib
+try:
+    # this module is faster
+    import cchardet
+except ImportError:
+    cchardet = None
+# https://charset-normalizer.readthedocs.io/en/latest/
+# https://ftfy.readthedocs.io/en/latest/
+
+import requests
+import urllib3
+
+MAX_FILE_SIZE = 20000000
+MIN_FILE_SIZE = 10
+
+LOGGER = logging.getLogger(__name__)
+
+# customize headers
+HEADERS = {
+    'Connection': 'close',  # another way to cover tracks
+    'User-Agent': 'Mozilla/5.0'
+}
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def isutf8(data):
+    """Simple heuristic to determine if a bytestring uses standard unicode encoding"""
+    try:
+        data.decode('UTF-8')
+    except UnicodeDecodeError:
+        return False
+    else:
+        return True
+
+
+def detect_encoding(bytesobject):
+    """Read the first chunk of input and return its encoding"""
+    # unicode-test
+    if isutf8(bytesobject):
+        return 'UTF-8'
+    # try one of the installed detectors
+    if cchardet is not None:
+        guess = cchardet.detect(bytesobject)
+        LOGGER.debug('guessed encoding: %s', guess['encoding'])
+        return guess['encoding']
+    # fallback on full response
+    # if guess is None or guess['encoding'] is None: # or guess['confidence'] < 0.99:
+    #    guessed_encoding = chardet.detect(bytesobject)['encoding']
+    # return
+    return None
+
+
+def decode_response(response):
+    """Read the first chunk of server response and decode it"""
+    guessed_encoding = detect_encoding(response.content)
+    LOGGER.debug('response/guessed encoding: %s / %s', response.encoding, guessed_encoding)
+    # process
+    if guessed_encoding is not None:
+        try:
+            htmltext = response.content.decode(guessed_encoding)
+        except UnicodeDecodeError:
+            LOGGER.warning('encoding error: %s / %s', response.encoding, guessed_encoding)
+            htmltext = response.text
+    else:
+        htmltext = response.text
+    return htmltext
 
 
 class SimpleCrawler(object):
@@ -26,14 +93,36 @@ class SimpleCrawler(object):
         :param timeout: in seconds, if None, the urllib default is used
         :return: html of the url
         """
-        headers = {'User-Agent': 'Mozilla/5.0'}
-        req = urllib.request.Request(url, None, headers)
-        html = urllib.request.urlopen(req, data=None, timeout=timeout).read()
-
+        html_str = None
+        # send
+        try:
+            # read by streaming chunks (stream=True, iter_content=xx)
+            # so we can stop downloading as soon as MAX_FILE_SIZE is reached
+            response = requests.get(url, timeout=timeout, verify=False, allow_redirects=True, headers=HEADERS)
+        except (requests.exceptions.MissingSchema, requests.exceptions.InvalidURL):
+            LOGGER.error('malformed URL: %s', url)
+        except requests.exceptions.TooManyRedirects:
+            LOGGER.error('redirects: %s', url)
+        except requests.exceptions.SSLError as err:
+            LOGGER.error('SSL: %s %s', url, err)
+        except (
+            socket.timeout, requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout, socket.error, socket.gaierror
+        ) as err:
+            LOGGER.error('connection: %s %s', url, err)
+        else:
+            # safety checks
+            if response.status_code != 200:
+                LOGGER.error('not a 200 response: %s', response.status_code)
+            elif response.text is None or len(response.text) < MIN_FILE_SIZE:
+                LOGGER.error('too small/incorrect: %s %s', url, len(response.text))
+            elif len(response.text) > MAX_FILE_SIZE:
+                LOGGER.error('too large: %s %s', url, len(response.text))
+            else:
+                html_str = decode_response(response)
         if is_threaded:
-            SimpleCrawler._results[url] = html
-
-        return html
+            SimpleCrawler._results[url] = html_str
+        return html_str
 
     @staticmethod
     def fetch_urls(urls, timeout=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ six>=1.10.0
 awscli>=1.11.117
 hurry.filesize>=0.9
 bs4
+cchardet


### PR DESCRIPTION
## Why 
To address #164 

## How
Use code from https://github.com/adbar/trafilatura/blob/master/trafilatura/utils.py to do _fetch_url()

## Test script
```python
from time import time
import datetime
from newsplease import NewsPlease
from newsplease.crawler.simple_crawler import SimpleCrawler

t = time()
url = 'https://www.nytimes.com/2017/02/23/us/politics/cpac-stephen-bannon-reince-priebus.html?hp'
url = 'https://www.fox5vegas.com/news/black-friday-shoppers-looking-for-best-deals/video_c236dde4-65c2-5bd6-983e-8b7b97a67a46.html'
html = SimpleCrawler.fetch_url(url, timeout=None)
print(type(html))
print(f"Crawl Time: {time() - t:.2f}s")

t = time()
download_date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
result = NewsPlease.from_html(html, url, download_date)
print(f"Parse Time: {time() - t:.2f}s")

t = time()
article = NewsPlease.from_url(url)
print(article.title)
print(f"Total Time: {time() - t:.2f}s")
```

## NOTE
For `url = 'https://www.nytimes.com/2017/02/23/us/politics/cpac-stephen-bannon-reince-priebus.html?hp'` there is no significant difference (0.4s vs 0.46s), but for `'https://www.fox5vegas.com/news/black-friday-shoppers-looking-for-best-deals/video_c236dde4-65c2-5bd6-983e-8b7b97a67a46.html'` it is >10x faster (1s vs 13.8s) for some reason. 