### PR TITLE
Commoncrawl crawler: use system temp file in a writable folder

### DIFF
--- a/newsplease/crawler/commoncrawl_crawler.py
+++ b/newsplease/crawler/commoncrawl_crawler.py
@@ -100,9 +100,20 @@ def __iterate_by_month(start_date, end_date, month_step=1):
                                             month=new_month)
 
 
+def __extract_date_from_warc_filename(path):
+    fn = os.path.basename(path)
+    # Assume the filename pattern is CC-NEWS-20160911145202-00018.warc.gz
+    fn = fn.replace('CC-NEWS-', '')
+    dt = fn.split('-')[0]
+
+    return datetime.datetime.strptime(dt, '%Y%m%d%H%M%S')
+
+
 def __get_remote_index(warc_files_start_date):
     """
     Gets the index of news crawl files from commoncrawl.org and returns an array of names
+    :param warc_files_start_date: only list .warc files with greater or equal date in
+    their filename
     :return:
     """
     temp_filename = ".tmpaws.txt"
@@ -122,6 +133,7 @@ def __get_remote_index(warc_files_start_date):
         except OSError:
             pass
 
+        # The news files are grouped per year and month in separate folders
         warc_dates = __iterate_by_month(warc_files_start_date, datetime.datetime.today())
         for date in warc_dates:
             year = date.strftime('%Y')
@@ -145,6 +157,12 @@ def __get_remote_index(warc_files_start_date):
         pass
 
     lines = stdout_data.splitlines()
+
+    if warc_files_start_date:
+        # Now filter further on day of month, hour, minute
+        lines = [p for p in lines
+                 if __extract_date_from_warc_filename(p) >= warc_files_start_date]
+
     return lines
 
 

--- a/newsplease/crawler/commoncrawl_crawler.py
+++ b/newsplease/crawler/commoncrawl_crawler.py
@@ -7,6 +7,7 @@ not otherwise specified.
 import logging
 import os
 import subprocess
+import tempfile
 import time
 from functools import partial
 from multiprocessing import Pool
@@ -116,45 +117,42 @@ def __get_remote_index(warc_files_start_date):
     their filename
     :return:
     """
-    temp_filename = ".tmpaws.txt"
 
-    if os.name == 'nt':
-        awk_parameter = '"{ print $4 }"'
-    else:
-        awk_parameter = "'{ print $4 }'"
+    with tempfile.NamedTemporaryFile() as temp:
+        temp_filename = temp.name
 
-    # get the remote info
+        if os.name == 'nt':
+            awk_parameter = '"{ print $4 }"'
+        else:
+            awk_parameter = "'{ print $4 }'"
 
-    cmd = ''
-    if warc_files_start_date:
-        # cleanup
-        try:
-            os.remove(temp_filename)
-        except OSError:
-            pass
+        # get the remote info
 
-        # The news files are grouped per year and month in separate folders
-        warc_dates = __iterate_by_month(warc_files_start_date, datetime.datetime.today())
-        for date in warc_dates:
-            year = date.strftime('%Y')
-            month = date.strftime('%m')
-            cmd += "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/%s/%s/ --no-sign-request >> %s && " % (year, month, temp_filename)
+        cmd = ''
+        if warc_files_start_date:
+            # cleanup
+            try:
+                os.remove(temp_filename)
+            except OSError:
+                pass
 
-    else:
-        cmd = "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/ --no-sign-request > %s && " % temp_filename
+            # The news files are grouped per year and month in separate folders
+            warc_dates = __iterate_by_month(warc_files_start_date, datetime.datetime.today())
+            for date in warc_dates:
+                year = date.strftime('%Y')
+                month = date.strftime('%m')
+                cmd += "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/%s/%s/ --no-sign-request >> %s && " % (year, month, temp_filename)
 
-    cmd += "awk %s %s " % (awk_parameter, temp_filename)
+        else:
+            cmd = "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/ --no-sign-request > %s && " % temp_filename
 
-    __logger.info('executing: %s', cmd)
-    exitcode, stdout_data = subprocess.getstatusoutput(cmd)
+        cmd += "awk %s %s " % (awk_parameter, temp_filename)
 
-    if exitcode > 0:
-        raise Exception(stdout_data)
+        __logger.info('executing: %s', cmd)
+        exitcode, stdout_data = subprocess.getstatusoutput(cmd)
 
-    try:
-        os.remove(temp_filename)
-    except OSError:
-        pass
+        if exitcode > 0:
+            raise Exception(stdout_data)
 
     lines = stdout_data.splitlines()
 

--- a/tools/combine_json_outut.py
+++ b/tools/combine_json_outut.py
@@ -1,0 +1,61 @@
+# This tool combines all json files written by news-please in one new file, one line per
+# json source document.
+# This output can then be used by Apache Hive (and therefore by Amazon Athena).
+import getopt
+import glob
+import json
+import logging
+import os
+import sys
+
+
+def get_files_by_ext(dirpath, pattern='*'):
+    if not os.path.exists(dirpath):
+        raise Exception("Path %s doesn't exit." % dirpath)
+
+    a = glob.glob(os.path.join(dirpath, "**", pattern), recursive=True)
+    a.sort(key=lambda s: os.path.getmtime(s))
+    return a
+
+
+def combine_json_files(source_folder, output_path):
+    paths = get_files_by_ext(source_folder, pattern="*.json")
+    with open(output_path, 'w') as of:
+        for p in paths:
+            with open(p, 'rb') as f:
+                json_input = f.readline()
+            of.write(json_input.decode("utf-8"))
+            of.write("\n")
+    pass
+
+
+
+def print_usage():
+    print("combine_json_output.py source_folder=<path to folder with json files>")
+
+def start(argv):
+    try:
+        opts, args = getopt.getopt(argv, "dh", longopts=["source_folder=", 'output_path='])
+    except getopt.GetoptError:
+        logging.exception("Problem while parsing options.")
+        print_usage()
+        sys.exit(2)
+
+    output_path = source_folder = None
+    for opt, arg in opts:
+        if opt == '-h':
+            print_usage()
+            sys.exit(0)
+        elif opt == '--source_folder':
+            source_folder = arg
+        elif opt == '--output_path':
+            output_path = arg
+
+    combine_json_files(source_folder, output_path)
+
+logging.basicConfig(level=logging.DEBUG,
+                    format='%(asctime)s %(levelname)s %(message)s')  # include timestamp
+
+if __name__ == '__main__':
+    start(sys.argv[1:])
+


### PR DESCRIPTION
Make the commoncrawl crawler when running in a docker container. Use a temp file opened by the system, not the hard-coded file .tmpaws.txt in the src directory that probably not writable.