### PR TITLE
Fixes #189: cchardet installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ six>=1.10.0
 awscli>=1.11.117
 hurry.filesize>=0.9
 bs4
-cchardet
+cchardet>=2.1.7


### PR DESCRIPTION
Fixes issue #189 where the `cchardet` library does not get installed automatically during set up. 
Altered the `requirements.txt` file to include the same.