### PR TITLE
Make filter_record public to enable subclasses to override

### DIFF
--- a/newsplease/crawler/commoncrawl_crawler.py
+++ b/newsplease/crawler/commoncrawl_crawler.py
@@ -216,7 +216,8 @@ def __start_commoncrawl_extractor(warc_download_url, callback_on_article_extract
                                   log_level=logging.ERROR,
                                   delete_warc_after_extraction=True,
                                   continue_process=True,
-                                  log_pathname_fully_extracted_warcs=None):
+                                  log_pathname_fully_extracted_warcs=None,
+                                  extractor_cls=CommonCrawlExtractor):
     """
     Starts a single CommonCrawlExtractor
     :param warc_download_url:
@@ -231,9 +232,10 @@ def __start_commoncrawl_extractor(warc_download_url, callback_on_article_extract
     :param continue_after_error:
     :param show_download_progress:
     :param log_level:
+    :param extractor_cls:
     :return:
     """
-    commoncrawl_extractor = CommonCrawlExtractor()
+    commoncrawl_extractor = extractor_cls()
     commoncrawl_extractor.extract_from_commoncrawl(warc_download_url, callback_on_article_extracted,
                                                    callback_on_warc_completed=callback_on_warc_completed,
                                                    valid_hosts=valid_hosts,
@@ -253,7 +255,8 @@ def crawl_from_commoncrawl(callback_on_article_extracted, callback_on_warc_compl
                            reuse_previously_downloaded_files=True, local_download_dir_warc=None, 
                            continue_after_error=True, show_download_progress=False,
                            number_of_extraction_processes=4, log_level=logging.ERROR,
-                           delete_warc_after_extraction=True, continue_process=True):
+                           delete_warc_after_extraction=True, continue_process=True,
+                           extractor_cls=CommonCrawlExtractor):
     """
     Crawl and extract articles form the news crawl provided by commoncrawl.org. For each article that was extracted
     successfully the callback function callback_on_article_extracted is invoked where the first parameter is the
@@ -271,6 +274,7 @@ def crawl_from_commoncrawl(callback_on_article_extracted, callback_on_warc_compl
     :param continue_after_error:
     :param show_download_progress:
     :param log_level:
+    :param extractor_cls:
     :return:
     """
     __setup(local_download_dir_warc, log_level)
@@ -319,7 +323,8 @@ def crawl_from_commoncrawl(callback_on_article_extracted, callback_on_warc_compl
                                                 show_download_progress=show_download_progress,
                                                 log_level=log_level,
                                                 delete_warc_after_extraction=delete_warc_after_extraction,
-                                                log_pathname_fully_extracted_warcs=__log_pathname_fully_extracted_warcs),
+                                                log_pathname_fully_extracted_warcs=__log_pathname_fully_extracted_warcs,
+                                                extractor_cls=extractor_cls),
                                         warc_download_urls)
     else:
         for warc_download_url in warc_download_urls:
@@ -335,4 +340,5 @@ def crawl_from_commoncrawl(callback_on_article_extracted, callback_on_warc_compl
                                           show_download_progress=show_download_progress,
                                           log_level=log_level,
                                           delete_warc_after_extraction=delete_warc_after_extraction,
-                                          log_pathname_fully_extracted_warcs=__log_pathname_fully_extracted_warcs)
+                                          log_pathname_fully_extracted_warcs=__log_pathname_fully_extracted_warcs,
+                                          extractor_cls=extractor_cls)

--- a/newsplease/crawler/commoncrawl_crawler.py
+++ b/newsplease/crawler/commoncrawl_crawler.py
@@ -232,7 +232,8 @@ def __start_commoncrawl_extractor(warc_download_url, callback_on_article_extract
     :param continue_after_error:
     :param show_download_progress:
     :param log_level:
-    :param extractor_cls:
+    :param extractor_cls: A subclass of CommonCrawlExtractor, which can be used
+        to add custom filtering by overriding .filter_record(...)
     :return:
     """
     commoncrawl_extractor = extractor_cls()

--- a/newsplease/crawler/commoncrawl_extractor.py
+++ b/newsplease/crawler/commoncrawl_extractor.py
@@ -93,7 +93,7 @@ class CommonCrawlExtractor:
         with open(self.__log_pathname_fully_extracted_warcs, 'a') as log_file:
             log_file.write(warc_url + '\n')
 
-    def __filter_record(self, warc_record, article=None):
+    def filter_record(self, warc_record, article=None):
         """
         Returns true if a record passes all tests: hosts, publishing date
         :param warc_record:
@@ -248,7 +248,7 @@ class CommonCrawlExtractor:
                         counter_article_total += 1
 
                         # if the article passes filter tests, we notify the user
-                        filter_pass, article = self.__filter_record(record)
+                        filter_pass, article = self.filter_record(record)
                         if filter_pass:
                             if not article:
                                 article = NewsPlease.from_warc(record)

--- a/newsplease/examples/commoncrawl.py
+++ b/newsplease/examples/commoncrawl.py
@@ -6,8 +6,13 @@ script stores the extracted articles in JSON files, but this behaviour can be ad
 on_valid_article_extracted. To speed up the crawling and extraction process, the script supports multiprocessing. You can
 control the number of processes with the parameter my_number_of_extraction_processes.
 
-You can also crawl and extract articles programmatically, i.e., from within your own code, by using the class
-CommonCrawlCrawler provided in newsplease.crawler.commoncrawl_crawler.py
+You can also crawl and extract articles programmatically, i.e., from within
+your own code, by using the class CommonCrawlCrawler or the function
+commoncrawl_crawler.crawl_from_commoncrawl(...) provided in
+newsplease.crawler.commoncrawl_crawler.py. In this case there is also the
+possibility of passing in a your own subclass of CommonCrawlExtractor as
+extractor_cls=... . One use case here is that your subclass can customise
+filtering by overriding `.filter_record(...)`.
 
 In case the script crashes and contains a log message in the beginning that states that only 1 file on AWS storage
 was found, make sure that awscli was correctly installed. You can check that by running aws --version from a terminal.


### PR DESCRIPTION
Subclasses are quite likely to want to override this if they want to provide custom fitlers, so let's make it public.