### PR TITLE
Fallback to bytes fromstring when lxml unicode fromstring fails

### DIFF
--- a/newsplease/pipeline/extractor/cleaner.py
+++ b/newsplease/pipeline/extractor/cleaner.py
@@ -27,7 +27,10 @@ class Cleaner:
         """
 
         if len(arg) > 0:
-            raw = html.fromstring(arg)
+            try:
+                raw = html.fromstring(arg)
+            except ValueError:
+                raw = html.fromstring(arg.encode("utf-8"))
             return raw.text_content().strip()
 
         return arg

--- a/newsplease/pipeline/extractor/extractors/lang_detect_extractor.py
+++ b/newsplease/pipeline/extractor/extractors/lang_detect_extractor.py
@@ -23,7 +23,10 @@ class LangExtractor(AbstractExtractor):
         with langdetect"""
 
         response = item['spider_response'].body
-        root = html.fromstring(response)
+        try:
+            root = html.fromstring(response)
+        except ValueError:
+            root = html.fromstring(response.encode("utf-8"))
 
         # Check for lang-attributes
         lang = root.get('lang')


### PR DESCRIPTION
This fixes errors introduced in https://github.com/fhamborg/news-please/pull/165 like (at least in the common case of the encoding being utf-8):

```
Traceback (most recent call last):
  File "/home/frankier/edu/doc/coviddash/.venv/lib/python3.9/site-packages/newsplease/crawler/commoncrawl_extractor.py", line 251, in __process_warc_gz_file
    filter_pass, article = self.filter_record(record)
  File "/home/frankier/edu/doc/coviddash/ingress/covidmarch.py", line 28, in filter_record
    passed_filters, article = super().filter_record(warc_record, article)
  File "/home/frankier/edu/doc/coviddash/.venv/lib/python3.9/site-packages/newsplease/crawler/commoncrawl_extractor.py", line 119, in filter_record
    article = NewsPlease.from_warc(warc_record)
  File "/home/frankier/edu/doc/coviddash/.venv/lib/python3.9/site-packages/newsplease/__init__.py", line 45, in from_warc
    article = NewsPlease.from_html(html, url=url, download_date=download_date)
  File "/home/frankier/edu/doc/coviddash/.venv/lib/python3.9/site-packages/newsplease/__init__.py", line 79, in from_html
    item = extractor.extract(item)
  File "/home/frankier/edu/doc/coviddash/.venv/lib/python3.9/site-packages/newsplease/pipeline/extractor/article_extractor.py", line 53, in extract
    article_candidate = extractor.extract(item)
  File "/home/frankier/edu/doc/coviddash/.venv/lib/python3.9/site-packages/newsplease/pipeline/extractor/extractors/abstract_extractor.py", line 64, in extract
    article_candidate.language = self._language(item)
  File "/home/frankier/edu/doc/coviddash/.venv/lib/python3.9/site-packages/newsplease/pipeline/extractor/extractors/lang_detect_extractor.py", line 26, in _language
    root = html.fromstring(response)
  File "/home/frankier/edu/doc/coviddash/.venv/lib/python3.9/site-packages/lxml/html/__init__.py", line 875, in fromstring
    doc = document_fromstring(html, parser=parser, base_url=base_url, **kw)
  File "/home/frankier/edu/doc/coviddash/.venv/lib/python3.9/site-packages/lxml/html/__init__.py", line 761, in document_fromstring
    value = etree.fromstring(html, parser, **kw)
  File "src/lxml/etree.pyx", line 3237, in lxml.etree.fromstring
  File "src/lxml/parser.pxi", line 1891, in lxml.etree._parseMemoryDocument
ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.
```