### PR TITLE
Avoid race condition by using exist_ok=True for makedirs rather than checking for exists first

### DIFF
--- a/newsplease/crawler/commoncrawl_crawler.py
+++ b/newsplease/crawler/commoncrawl_crawler.py
@@ -48,8 +48,7 @@ def __setup(local_download_dir_warc, log_level):
     Setup
     :return:
     """
-    if not os.path.exists(local_download_dir_warc):
-        os.makedirs(local_download_dir_warc)
+    os.makedirs(local_download_dir_warc, exist_ok=True)
 
     global __log_pathname_fully_extracted_warcs
     __log_pathname_fully_extracted_warcs = os.path.join(local_download_dir_warc, 'fullyextractedwarcs.list')

--- a/newsplease/crawler/commoncrawl_extractor.py
+++ b/newsplease/crawler/commoncrawl_extractor.py
@@ -67,8 +67,7 @@ class CommonCrawlExtractor:
         Setup
         :return:
         """
-        if not os.path.exists(self.__local_download_dir_warc):
-            os.makedirs(self.__local_download_dir_warc)
+        os.makedirs(self.__local_download_dir_warc, exist_ok=True)
 
         # make loggers quite
         configure_logging({"LOG_LEVEL": "ERROR"})

--- a/newsplease/examples/commoncrawl.py
+++ b/newsplease/examples/commoncrawl.py
@@ -79,8 +79,7 @@ def __setup__():
     Setup
     :return:
     """
-    if not os.path.exists(my_local_download_dir_article):
-        os.makedirs(my_local_download_dir_article)
+    os.makedirs(my_local_download_dir_article, exist_ok=True)
 
 
 def __get_pretty_filepath(path, article):
@@ -93,8 +92,7 @@ def __get_pretty_filepath(path, article):
     short_filename = hashlib.sha256(article.filename.encode()).hexdigest()
     sub_dir = article.source_domain
     final_path = os.path.join(path, sub_dir)
-    if not os.path.exists(final_path):
-        os.makedirs(final_path)
+    os.makedirs(final_path, exist_ok=True)
     return os.path.join(final_path, short_filename + '.json')
 
 

--- a/newsplease/pipeline/pipelines.py
+++ b/newsplease/pipeline/pipelines.py
@@ -524,8 +524,7 @@ class HtmlFileStorage(ExtractedInformationStorage):
 
         # Ensure path exists
         dir_ = os.path.dirname(item['abs_local_path'])
-        if not os.path.exists(dir_):
-            os.makedirs(dir_)
+        os.makedirs(dir_, exist_ok=True)
 
         # Write raw html to local file system
         with open(item['abs_local_path'], 'wb') as file_:
@@ -550,8 +549,7 @@ class JsonFileStorage(ExtractedInformationStorage):
 
         # Ensure path exists
         dir_ = os.path.dirname(item['abs_local_path'])
-        if not os.path.exists(dir_):
-            os.makedirs(dir_)
+        os.makedirs(dir_, exist_ok=True)
 
         # Write JSON to local file system
         with open(file_path, 'w') as file_:


### PR DESCRIPTION
Checking first can cause a race condition if the directory is created in another process first in between the check and the creation. This is also a big problem for networked file systems (e.g. in cluster computing environments) which can return old data for reads. The exist_ok=True flag has atomic behaviour as required.