### PR TITLE
Add option of replacing unicode decode errors in WARC/common crawl extraction

### DIFF
--- a/newsplease/__init__.py
+++ b/newsplease/__init__.py
@@ -39,7 +39,11 @@ class NewsPlease:
             # assume utf-8
             encoding = 'utf-8'
 
-        html = raw_stream.decode(encoding, errors=decode_errors)
+        try:
+            html = raw_stream.decode(encoding, errors=decode_errors)
+        except LookupError:
+            # non-existent encoding: fallback to utf-9
+            html = raw_stream.decode('utf-8', errors=decode_errors)
         url = warc_record.rec_headers.get_header('WARC-Target-URI')
         download_date = warc_record.rec_headers.get_header('WARC-Date')
         article = NewsPlease.from_html(html, url=url, download_date=download_date)

--- a/newsplease/__init__.py
+++ b/newsplease/__init__.py
@@ -21,7 +21,7 @@ class NewsPlease:
     """
 
     @staticmethod
-    def from_warc(warc_record):
+    def from_warc(warc_record, decode_errors="replace"):
         """
         Extracts relevant information from a WARC record. This function does not invoke scrapy but only uses the article
         extractor.
@@ -39,7 +39,7 @@ class NewsPlease:
             # assume utf-8
             encoding = 'utf-8'
 
-        html = raw_stream.decode(encoding)
+        html = raw_stream.decode(encoding, errors=decode_errors)
         url = warc_record.rec_headers.get_header('WARC-Target-URI')
         download_date = warc_record.rec_headers.get_header('WARC-Date')
         article = NewsPlease.from_html(html, url=url, download_date=download_date)


### PR DESCRIPTION
This fixes the current exception by either explicitly replacing undecodable unicode characters or skipping those documents altogether.