### PR TITLE
Added cchardet installation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ news-please supports three main use cases, which are explained in more detail in
 ## Getting started
 It's super easy, we promise!
 
+### Requirements
+news-please depends on cchardet for character encoding
+```
+$ pip3 install cchardet
+```
+
 ### Installation
 news-please runs on Python 3.5+.
 ```


### PR DESCRIPTION
I tried installing news-please based on the README instructions but couldn't get it to work. Seems I was missing cchardet on my system. I found a closed issue that talked about installing this dependency and once it was installed news-please worked.

I thought it would be a good idea to add these instructions in the README for future users.