### PR TITLE
Common Crawl crawler: adapt to new data access scheme, fixes #223

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ news-please supports three main use cases, which are explained in more detail in
 * commoncrawl.org provides an extensive, free-to-use archive of news articles from small and major publishers world wide
 * news-please enables users to conveniently download and extract articles from commoncrawl.org
 * you can optionally define filter criteria, such as news publisher(s) or the date period, within which articles need to be published
-* clone the news-please repository, [install the awscli tool](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html), adapt the config section in [newsplease/examples/commoncrawl.py](/newsplease/examples/commoncrawl.py), and execute `python3 -m newsplease.examples.commoncrawl`
+* clone the news-please repository, adapt the config section in [newsplease/examples/commoncrawl.py](/newsplease/examples/commoncrawl.py), and execute `python3 -m newsplease.examples.commoncrawl`
 
 ## Getting started
 It's super easy, we promise!

--- a/newsplease/crawler/commoncrawl_crawler.py
+++ b/newsplease/crawler/commoncrawl_crawler.py
@@ -108,12 +108,15 @@ def __iterate_by_month(start_date=None, end_date=None, month_step=1):
         # Until now.
         end_date = datetime.datetime.today()
     current_date = start_date
-    while current_date < end_date:
-        yield current_date
+    yield current_date
+    while True:
         carry, new_month = divmod(current_date.month - 1 + month_step, 12)
         new_month += 1
         current_date = current_date.replace(year=current_date.year + carry,
                                             month=new_month)
+        yield current_date
+        if current_date > end_date:
+            break
 
 
 def __extract_date_from_warc_filename(path):

--- a/newsplease/crawler/commoncrawl_crawler.py
+++ b/newsplease/crawler/commoncrawl_crawler.py
@@ -122,7 +122,11 @@ def __extract_date_from_warc_filename(path):
     fn = fn.replace('CC-NEWS-', '')
     dt = fn.split('-')[0]
 
-    return datetime.datetime.strptime(dt, '%Y%m%d%H%M%S')
+    try:
+        return datetime.datetime.strptime(dt, '%Y%m%d%H%M%S')
+    except:
+        # return date clearly outside the range
+        return datetime.datetime(1900, 1, 1)
 
 
 def __date_within_period(date, start_date=None, end_date=None):

--- a/newsplease/crawler/commoncrawl_crawler.py
+++ b/newsplease/crawler/commoncrawl_crawler.py
@@ -6,14 +6,17 @@ not otherwise specified.
 """
 import logging
 import os
-import subprocess
-import tempfile
 import time
 from functools import partial
 from multiprocessing import Pool
 import datetime
+import gzip
+from urllib.parse import urlparse
 
+import boto3
+import botocore
 from dateutil import parser
+import requests
 from scrapy.utils.log import configure_logging
 
 from ..crawler.commoncrawl_extractor import CommonCrawlExtractor
@@ -23,7 +26,8 @@ __copyright__ = "Copyright 2017"
 __credits__ = ["Sebastian Nagel"]
 
 # commoncrawl.org
-__cc_base_url = 'https://commoncrawl.s3.amazonaws.com/'
+__cc_base_url = 'https://data.commoncrawl.org/'
+__cc_bucket = 'commoncrawl'
 
 # log file of fully extracted WARC files
 __log_pathname_fully_extracted_warcs = None
@@ -56,7 +60,7 @@ def __setup(local_download_dir_warc, log_level):
     global __log_pathname_fully_extracted_warcs
     __log_pathname_fully_extracted_warcs = os.path.join(local_download_dir_warc, 'fullyextractedwarcs.list')
 
-    # make loggers quite
+    # make loggers quiet
     configure_logging({"LOG_LEVEL": "ERROR"})
     logging.getLogger('requests').setLevel(logging.CRITICAL)
     logging.getLogger('readability').setLevel(logging.CRITICAL)
@@ -65,6 +69,9 @@ def __setup(local_download_dir_warc, log_level):
     logging.getLogger('newsplease').setLevel(logging.CRITICAL)
     logging.getLogger('urllib3').setLevel(logging.CRITICAL)
     logging.getLogger('jieba').setLevel(logging.CRITICAL)
+
+    boto3.set_stream_logger('botocore', log_level)
+    boto3.set_stream_logger('boto3', log_level)
 
     # set own logger
     logging.basicConfig(level=log_level)
@@ -128,7 +135,7 @@ def __date_within_period(date, start_date=None, end_date=None):
     return start_date <= date < end_date
 
 
-def __get_remote_index(warc_files_start_date, warc_files_end_date):
+def __get_remote_index(warc_files_start_date=None, warc_files_end_date=None):
     """
     Gets the index of news crawl files from commoncrawl.org and returns an array of names
     :param warc_files_start_date: only list .warc files with greater or equal date in
@@ -137,58 +144,73 @@ def __get_remote_index(warc_files_start_date, warc_files_end_date):
     :return:
     """
 
-    with tempfile.NamedTemporaryFile() as temp:
-        temp_filename = temp.name
+    s3_client = boto3.client('s3')
+    # Verify access to commoncrawl bucket
+    try:
+        s3_client.head_bucket(Bucket=__cc_bucket)
+    except (botocore.exceptions.ClientError, botocore.exceptions.NoCredentialsError):
+        __logger.info('Failed to read %s bucket, using monthly WARC file listings', __cc_bucket)
+        s3_client = None
 
-        if os.name == 'nt':
-            awk_parameter = '"{ print $4 }"'
-        else:
-            awk_parameter = "'{ print $4 }'"
+    objects = []
 
-        # get the remote info
+    if s3_client:
+        def s3_list_objects(bucket, prefix):
+            response = s3_client.list_objects(Bucket=bucket, Prefix=prefix)
+            if 'Contents' not in response:
+                return []
+            return [x['Key'] for x in response['Contents']]
 
-        cmd = ''
         if warc_files_start_date or warc_files_end_date:
-            # cleanup
-            try:
-                os.remove(temp_filename)
-            except OSError:
-                pass
-
             # The news files are grouped per year and month in separate folders
             warc_dates = __iterate_by_month(start_date=warc_files_start_date, end_date=warc_files_end_date)
             for date in warc_dates:
                 year = date.strftime('%Y')
                 month = date.strftime('%m')
-                cmd += "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/%s/%s/ --no-sign-request >> %s && " % (year, month, temp_filename)
-
+                prefix = 'crawl-data/CC-NEWS/%s/%s/' % (year, month)
+                __logger.debug('Listing objects on S3 bucket %s and prefix %s', __cc_bucket, prefix)
+                objects += s3_list_objects(__cc_bucket, prefix)
         else:
-            cmd = "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/ --no-sign-request > %s && " % temp_filename
+            objects = s3_list_objects(__cc_bucket, 'crawl-data/CC-NEWS/')
 
-        cmd += "awk %s %s " % (awk_parameter, temp_filename)
-
-        __logger.info('executing: %s', cmd)
-        exitcode, stdout_data = subprocess.getstatusoutput(cmd)
-
-        if exitcode > 0:
-            raise Exception(stdout_data)
-
-    lines = stdout_data.splitlines()
+    else:
+        # The news files are grouped per year and month in separate folders
+        warc_dates = __iterate_by_month(start_date=warc_files_start_date, end_date=warc_files_end_date)
+        for date in warc_dates:
+            year = date.strftime('%Y')
+            month = date.strftime('%m')
+            url = '%scrawl-data/CC-NEWS/%s/%s/warc.paths.gz' % (__cc_base_url, year, month)
+            __logger.debug('Fetching WARC paths listing %s', url)
+            response = requests.get(url)
+            if response:
+                objects += gzip.decompress(response.content).decode('ascii').strip().split('\n')
+            else:
+                __logger.info('Failed to fetch WARC file list %s: %s', url, response)
 
     if warc_files_start_date or warc_files_end_date:
         # Now filter further on day of month, hour, minute
-        lines = [
-            p for p in lines if __date_within_period(
+        objects = [
+            p for p in objects if __date_within_period(
                 __extract_date_from_warc_filename(p),
                 start_date=warc_files_start_date,
                 end_date=warc_files_end_date,
             )
         ]
 
-    return lines
+    __logger.info('Found %i WARC files', len(objects))
 
+    return objects
 
-def __get_list_of_fully_extracted_warc_urls():
+def __get_url_path(url_or_path):
+    if url_or_path.startswith('http:') or url_or_path.startswith('https:'):
+        try:
+            url = urlparse(url_or_path)
+            return url.path.lstrip('/') # trim leading slash
+        except:
+            pass
+    return url_or_path
+
+def __get_list_of_fully_extracted_warc_paths():
     """
     Reads in the log file that contains a list of all previously, fully extracted WARC urls
     :return:
@@ -200,6 +222,9 @@ def __get_list_of_fully_extracted_warc_urls():
         list_warcs = log_file.readlines()
     # remove break lines
     list_warcs = [x.strip() for x in list_warcs]
+
+    # (back-ward compatibility) if it's a URL keep only the path
+    list_warcs = [__get_url_path(x) for x in list_warcs]
 
     return list_warcs
 
@@ -247,7 +272,7 @@ def __callback_on_warc_completed(warc_path, counter_article_passed, counter_arti
                                         __counter_article_error, __counter_article_total, __counter_warc_processed)
 
 
-def __start_commoncrawl_extractor(warc_download_url, callback_on_article_extracted=None,
+def __start_commoncrawl_extractor(warc_path, callback_on_article_extracted=None,
                                   callback_on_warc_completed=None, valid_hosts=None,
                                   start_date=None, end_date=None,
                                   strict_date=True, reuse_previously_downloaded_files=True,
@@ -261,7 +286,7 @@ def __start_commoncrawl_extractor(warc_download_url, callback_on_article_extract
                                   fetch_images=False):
     """
     Starts a single CommonCrawlExtractor
-    :param warc_download_url:
+    :param warc_path: path to the WARC file on s3://commoncrawl/ resp. https://data.commoncrawl.org/
     :param callback_on_article_extracted:
     :param callback_on_warc_completed:
     :param valid_hosts:
@@ -278,7 +303,7 @@ def __start_commoncrawl_extractor(warc_download_url, callback_on_article_extract
     :return:
     """
     commoncrawl_extractor = extractor_cls()
-    commoncrawl_extractor.extract_from_commoncrawl(warc_download_url, callback_on_article_extracted,
+    commoncrawl_extractor.extract_from_commoncrawl(warc_path, callback_on_article_extracted,
                                                    callback_on_warc_completed=callback_on_warc_completed,
                                                    valid_hosts=valid_hosts,
                                                    start_date=start_date, end_date=end_date,
@@ -334,27 +359,26 @@ def crawl_from_commoncrawl(callback_on_article_extracted, callback_on_warc_compl
 
     # multiprocessing (iterate the list of crawl_names, and for each: download and process it)
     __logger.info('creating extraction process pool with %i processes', number_of_extraction_processes)
-    warc_download_urls = []
-    fully_extracted_warc_urls = __get_list_of_fully_extracted_warc_urls()
-    for name in cc_news_crawl_names:
-        warc_download_url = __get_download_url(name)
+    warc_paths = []
+    fully_extracted_warc_paths = __get_list_of_fully_extracted_warc_paths()
+    for warc_path in cc_news_crawl_names:
         if continue_process:
             # check if the current WARC has already been fully extracted (assuming that the filter criteria have not
             # been changed!)
-            if warc_download_url in fully_extracted_warc_urls:
-                __logger.info('skipping WARC because fully extracted: %s' % warc_download_url)
+            if warc_path in fully_extracted_warc_paths:
+                __logger.info('skipping WARC because fully extracted: %s', warc_path)
                 global __counter_warc_skipped
                 __counter_warc_skipped += 1
                 pass
             else:
-                warc_download_urls.append(warc_download_url)
+                warc_paths.append(warc_path)
 
         else:
             # if not continue process, then always add
-            warc_download_urls.append(warc_download_url)
+            warc_paths.append(warc_path)
 
     # run the crawler in the current, single process if number of extraction processes is set to 1
-    if number_of_extraction_processes > 1:
+    elif number_of_extraction_processes > 1:
         with Pool(number_of_extraction_processes) as extraction_process_pool:
             extraction_process_pool.map(partial(__start_commoncrawl_extractor,
                                                 callback_on_article_extracted=callback_on_article_extracted,
@@ -371,10 +395,10 @@ def crawl_from_commoncrawl(callback_on_article_extracted, callback_on_warc_compl
                                                 log_pathname_fully_extracted_warcs=__log_pathname_fully_extracted_warcs,
                                                 extractor_cls=extractor_cls,
                                                 fetch_images=fetch_images),
-                                        warc_download_urls)
+                                        warc_paths)
     else:
-        for warc_download_url in warc_download_urls:
-            __start_commoncrawl_extractor(warc_download_url,
+        for warc_path in warc_paths:
+            __start_commoncrawl_extractor(warc_path,
                                           callback_on_article_extracted=callback_on_article_extracted,
                                           callback_on_warc_completed=__callback_on_warc_completed,
                                           valid_hosts=valid_hosts,

--- a/newsplease/crawler/commoncrawl_crawler.py
+++ b/newsplease/crawler/commoncrawl_crawler.py
@@ -324,7 +324,8 @@ def crawl_from_commoncrawl(callback_on_article_extracted, callback_on_warc_compl
                            continue_after_error=True, show_download_progress=False,
                            number_of_extraction_processes=4, log_level=logging.ERROR,
                            delete_warc_after_extraction=True, continue_process=True,
-                           extractor_cls=CommonCrawlExtractor, fetch_images=False):
+                           extractor_cls=CommonCrawlExtractor, fetch_images=False,
+                           dry_run=False):
     """
     Crawl and extract articles form the news crawl provided by commoncrawl.org. For each article that was extracted
     successfully the callback function callback_on_article_extracted is invoked where the first parameter is the
@@ -345,6 +346,7 @@ def crawl_from_commoncrawl(callback_on_article_extracted, callback_on_warc_compl
     :param show_download_progress:
     :param log_level:
     :param extractor_cls:
+    :param dry_run: if True just list the WARC files to be processed but do not actually process them
     :return:
     """
     __setup(local_download_dir_warc, log_level)
@@ -376,6 +378,10 @@ def crawl_from_commoncrawl(callback_on_article_extracted, callback_on_warc_compl
         else:
             # if not continue process, then always add
             warc_paths.append(warc_path)
+
+    if dry_run:
+        for warc_path in warc_paths:
+            __logger.info('(Dry run) Selected WARC file for processing: %s', warc_path)
 
     # run the crawler in the current, single process if number of extraction processes is set to 1
     elif number_of_extraction_processes > 1:

--- a/newsplease/crawler/commoncrawl_extractor.py
+++ b/newsplease/crawler/commoncrawl_extractor.py
@@ -6,11 +6,12 @@ not otherwise specified.
 """
 import logging
 import os
-import subprocess
 import sys
 import time
 
 from ago import human
+import boto3
+import botocore
 from dateutil import parser
 from hurry.filesize import size
 from scrapy.utils.log import configure_logging
@@ -18,6 +19,7 @@ from six.moves import urllib
 from warcio.archiveiterator import ArchiveIterator
 
 from .. import NewsPlease, EmptyResponseError
+from . import commoncrawl_crawler
 
 __author__ = "Felix Hamborg"
 __copyright__ = "Copyright 2017"
@@ -26,7 +28,7 @@ __credits__ = ["Sebastian Nagel"]
 
 class CommonCrawlExtractor:
     # remote url where we can download the warc file
-    __warc_download_url = None
+    __warc_path = None
     # download dir for warc files
     __local_download_dir_warc = './cc_download_warc/'
     # hosts (if None or empty list, any host is OK)
@@ -53,6 +55,7 @@ class CommonCrawlExtractor:
 
     # commoncrawl.org
     __cc_base_url = 'https://data.commoncrawl.org/'
+    __cc_bucket = 'commoncrawl'
     __cc_news_crawl_names = None
 
     # event handler called when an article was extracted successfully and passed all filter criteria
@@ -73,7 +76,7 @@ class CommonCrawlExtractor:
         """
         os.makedirs(self.__local_download_dir_warc, exist_ok=True)
 
-        # make loggers quite
+        # make loggers quiet
         configure_logging({"LOG_LEVEL": "ERROR"})
         logging.getLogger('requests').setLevel(logging.CRITICAL)
         logging.getLogger('readability').setLevel(logging.CRITICAL)
@@ -82,12 +85,16 @@ class CommonCrawlExtractor:
         logging.getLogger('newsplease').setLevel(logging.CRITICAL)
         logging.getLogger('urllib3').setLevel(logging.CRITICAL)
 
+        boto3.set_stream_logger('botocore', self.__log_level)
+        boto3.set_stream_logger('boto3', self.__log_level)
+        boto3.set_stream_logger('s3transfer', self.__log_level)
+
         # set own logger
         logging.basicConfig(level=self.__log_level)
         self.__logger = logging.getLogger(__name__)
         self.__logger.setLevel(self.__log_level)
 
-    def __register_fully_extracted_warc_file(self, warc_url):
+    def __register_fully_extracted_warc_file(self, warc_path):
         """
         Saves the URL warc_url in the log file for fully extracted WARC URLs
         :param warc_url:
@@ -95,7 +102,7 @@ class CommonCrawlExtractor:
         """
         if self.__log_pathname_fully_extracted_warcs is not None:
             with open(self.__log_pathname_fully_extracted_warcs, 'a') as log_file:
-                log_file.write(warc_url + '\n')
+                log_file.write(warc_path + '\n')
 
     def filter_record(self, warc_record, article=None):
         """
@@ -146,45 +153,12 @@ class CommonCrawlExtractor:
         else:
             return None
 
-    def __get_download_url(self, name):
-        """
-        Creates a download url given the name
-        :param name:
-        :return:
-        """
-        return self.__cc_base_url + name
-
     def __get_remote_index(self):
         """
         Gets the index of news crawl files from commoncrawl.org and returns an array of names
         :return:
         """
-        temp_filename = "tmpaws.txt"
-
-        if os.name == 'nt':
-            awk_parameter = '"{ print $4 }"'
-        else:
-            awk_parameter = "'{ print $4 }'"
-
-        # get the remote info
-        cmd = "aws s3 ls --recursive s3://commoncrawl/crawl-data/CC-NEWS/ --no-sign-request > %s && " \
-              "awk %s %s " % (temp_filename, awk_parameter, temp_filename)
-
-        self.__logger.info('executing: %s', cmd)
-        exitcode, stdout_data = subprocess.getstatusoutput(cmd)
-
-        if exitcode > 0:
-            raise Exception(stdout_data)
-
-        print(stdout_data)
-
-        try:
-            os.remove(temp_filename)
-        except OSError:
-            pass
-
-        lines = stdout_data.splitlines()
-        return lines
+        return commoncrawl_crawler.__get_remote_index()
 
     def __on_download_progress_update(self, blocknum, blocksize, totalsize):
         """
@@ -206,13 +180,13 @@ class CommonCrawlExtractor:
         else:  # total size is unknown
             sys.stdout.write("\rread %s" % (size(readsofar)))
 
-    def __download(self, url):
+    def __download(self, path):
         """
         Download and save a file locally.
         :param url: Where to download from
         :return: File path name of the downloaded file
         """
-        local_filename = urllib.parse.quote_plus(url)
+        local_filename = urllib.parse.quote_plus(path)
         local_filepath = os.path.join(self.__local_download_dir_warc, local_filename)
 
         if os.path.isfile(local_filepath) and self.__reuse_previously_downloaded_files:
@@ -226,10 +200,16 @@ class CommonCrawlExtractor:
                 pass
 
             # download
-            self.__logger.info('downloading %s (local: %s)', url, local_filepath)
-            urllib.request.urlretrieve(url, local_filepath, reporthook=self.__on_download_progress_update)
-            self.__logger.info('download completed, local file: %s', local_filepath)
-            return local_filepath
+            if self.__s3_client:
+                with open(local_filepath, 'wb') as file_obj:
+                    self.__s3_client.download_fileobj(self.__cc_bucket, path, file_obj)
+                    return local_file_path
+            else:
+                url = self.__cc_base_url + path
+                self.__logger.info('downloading %s (local: %s)', url, local_filepath)
+                urllib.request.urlretrieve(url, local_filepath, reporthook=self.__on_download_progress_update)
+                self.__logger.info('download completed, local file: %s', local_filepath)
+                return local_filepath
 
     def _from_warc(self, record):
         return NewsPlease.from_warc(record, decode_errors="replace" if self.__ignore_unicode_errors else "strict", fetch_images=self.__fetch_images)
@@ -304,8 +284,8 @@ class CommonCrawlExtractor:
         if self.__delete_warc_after_extraction:
             os.remove(path_name)
 
-        self.__register_fully_extracted_warc_file(self.__warc_download_url)
-        self.__callback_on_warc_completed(self.__warc_download_url, counter_article_passed, counter_article_discarded,
+        self.__register_fully_extracted_warc_file(self.__warc_path)
+        self.__callback_on_warc_completed(self.__warc_path, counter_article_passed, counter_article_discarded,
                                           counter_article_error, counter_article_total)
 
     def __run(self):
@@ -317,10 +297,10 @@ class CommonCrawlExtractor:
         """
         self.__setup()
 
-        local_path_name = self.__download(self.__warc_download_url)
+        local_path_name = self.__download(self.__warc_path)
         self.__process_warc_gz_file(local_path_name)
 
-    def extract_from_commoncrawl(self, warc_download_url, callback_on_article_extracted,
+    def extract_from_commoncrawl(self, warc_path, callback_on_article_extracted,
                                  callback_on_warc_completed=None,
                                  valid_hosts=None,
                                  start_date=None, end_date=None,
@@ -334,7 +314,7 @@ class CommonCrawlExtractor:
         article object.
         :param log_pathname_fully_extracted_warcs:
         :param delete_warc_after_extraction:
-        :param warc_download_url:
+        :param warc_path:
         :param callback_on_article_extracted:
         :param callback_on_warc_completed:
         :param valid_hosts:
@@ -348,7 +328,7 @@ class CommonCrawlExtractor:
         :param log_level:
         :return:
         """
-        self.__warc_download_url = warc_download_url
+        self.__warc_path = warc_path
         self.__filter_valid_hosts = valid_hosts
         self.__filter_start_date = start_date
         self.__filter_end_date = end_date
@@ -365,5 +345,15 @@ class CommonCrawlExtractor:
         self.__log_level = log_level
         self.__delete_warc_after_extraction = delete_warc_after_extraction
         self.__log_pathname_fully_extracted_warcs = log_pathname_fully_extracted_warcs
+
+        self.__s3_client = None
+        try:
+            s3_client = boto3.client('s3')
+            # Verify access to commoncrawl bucket
+            s3_client.head_bucket(Bucket=self.__cc_bucket)
+            self.__s3_client = s3_client
+        except (botocore.exceptions.ClientError, botocore.exceptions.NoCredentialsError):
+            self.__logger.info('Failed to read %s bucket, using monthly WARC file listings', self.__cc_bucket)
+
 
         self.__run()

--- a/newsplease/crawler/commoncrawl_extractor.py
+++ b/newsplease/crawler/commoncrawl_extractor.py
@@ -203,7 +203,7 @@ class CommonCrawlExtractor:
             if self.__s3_client:
                 with open(local_filepath, 'wb') as file_obj:
                     self.__s3_client.download_fileobj(self.__cc_bucket, path, file_obj)
-                    return local_file_path
+                return local_filepath
             else:
                 url = self.__cc_base_url + path
                 self.__logger.info('downloading %s (local: %s)', url, local_filepath)

--- a/newsplease/examples/commoncrawl.py
+++ b/newsplease/examples/commoncrawl.py
@@ -14,10 +14,6 @@ possibility of passing in a your own subclass of CommonCrawlExtractor as
 extractor_cls=... . One use case here is that your subclass can customise
 filtering by overriding `.filter_record(...)`.
 
-In case the script crashes and contains a log message in the beginning that states that only 1 file on AWS storage
-was found, make sure that awscli was correctly installed. You can check that by running aws --version from a terminal.
-If aws is not installed, you can (on Ubuntu) also install it using sudo apt-get install awscli.
-
 This script uses relative imports to ensure that the latest, local version of news-please is used, instead of the one
 that might have been installed with pip. Hence, you must run this script following this workflow.
 git clone https://github.com/fhamborg/news-please.git
@@ -84,6 +80,8 @@ my_continue_process = True
 # do not contain any images, so that news-please will crawl the current image from
 # the articles online webpage, if this option is enabled.
 my_fetch_images = False
+# if True, just list the WARC files to be processed, but do not actually download and process them
+my_dry_run=False
 ############ END YOUR CONFIG #########
 
 
@@ -183,7 +181,8 @@ def main():
                                                log_level=my_log_level,
                                                delete_warc_after_extraction=my_delete_warc_after_extraction,
                                                continue_process=True,
-                                               fetch_images=my_fetch_images)
+                                               fetch_images=my_fetch_images,
+                                               dry_run=my_dry_run)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ dotmap>=1.2.17
 warcio>=1.3.3
 ago>=0.0.9
 six>=1.10.0
-awscli>=1.11.117
 hurry.filesize>=0.9
 bs4
 cchardet>=2.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ awscli>=1.11.117
 hurry.filesize>=0.9
 bs4
 cchardet>=2.1.7
+boto3

--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,10 @@ news-please is an open source, easy-to-use news crawler that extracts structured
           'ago>=0.0.9',
           'six>=1.10.0',
           'lxml>=3.3.5',
-          'awscli>=1.11.117',
           'hurry.filesize>=0.9',
           'bs4',
-          'cchardet>=2.1.7'
+          'cchardet>=2.1.7',
+          'boto3'
       ],
       extras_require={
           ':sys_platform == "win32"': [


### PR DESCRIPTION
In order to support both authenticated access via the S3 API and anonymous access via HTTP (see #223):
- First, try to instantiated an S3 client using the default configuration (see [boto3: configure credentials](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials)). If the S3 client is successfully instantiated, it's used both to list and download WARC files.
- If using the S3 client fails, WARC files are downloaded using https://data.commoncrawl.org/ as base URL. The available WARC file listings (`warc.paths.gz`) are used to get the list of all WARC files for the configured time span.

This PR also addresses:
- fixes a bug in the selection of months for the configured time span: WARC file listings for the last month in the time span weren't always achieved.
- add a parameter `dry_run` to let the crawler list the WARC files to be processed without actually processing them