### PR TITLE
Fix Elasticsearch package version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Scrapy>=1.1.0
 PyMySQL>=0.7.9
 psycopg2-binary>=2.8.4
 hjson>=1.5.8
-elasticsearch>=2.4
+elasticsearch==7.17.3
 beautifulsoup4>=4.3.2
 readability-lxml>=0.6.2
 newspaper3k>=0.2.8

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ news-please is an open source, easy-to-use news crawler that extracts structured
           'PyMySQL>=0.7.9',
           'psycopg2-binary>=2.8.4',
           'hjson>=1.5.8',
-          'elasticsearch>=2.4',
+          'elasticsearch==7.17.3',
           'beautifulsoup4>=4.3.2',
           'readability-lxml>=0.6.2',
           'newspaper3k>=0.2.8',


### PR DESCRIPTION
The current setup rule will install the recent Elasticsearch version `8.2.0` which the `news-please` does not support it yet.
this will throw `__init__ got unexpected argument [port]` error