### PR TITLE
Replace cchardet with the Python 3.11.x compatible faust-cchardet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ ago>=0.0.9
 six>=1.10.0
 hurry.filesize>=0.9
 bs4
-cchardet>=2.1.7
+faust-cchardet>=2.1.18
 boto3

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ news-please is an open source, easy-to-use news crawler that extracts structured
           'lxml>=3.3.5',
           'hurry.filesize>=0.9',
           'bs4',
-          'cchardet>=2.1.7',
+          'faust-cchardet>=2.1.18',
           'boto3'
       ],
       extras_require={


### PR DESCRIPTION
Hey,

thanks for all your work on `news-please`. We recently looked into bumping our production setup to Python 3.11 and realized that there is a transitive dependency that holds us back. I wonder if you would be willing to merge this PR to support Python 3.11 and onwards.

AFAIK, `cchardet` is not actively maintained, and lacks support for Python 3.11.x. There is a drop-in replacement in the form of the `faust-cchardet` package that other package maintainers seem to adopt (https://github.com/mailgun/talon/pull/233). The forked `news-please` repo passes our CI with these changes, but let me know if there are any other concerns from your side.

Thank You,
Hannes