### PR TITLE
Make SimpleCrawer.fetch_urls() accept custom timeout

### DIFF
--- a/newsplease/__init__.py
+++ b/newsplease/__init__.py
@@ -145,7 +145,7 @@ class NewsPlease:
             html = SimpleCrawler.fetch_url(url, timeout=timeout)
             results[url] = NewsPlease.from_html(html, url, download_date)
         else:
-            results = SimpleCrawler.fetch_urls(urls)
+            results = SimpleCrawler.fetch_urls(urls, timeout=timeout)
 
             futures = {}
             with cf.ProcessPoolExecutor() as exec:


### PR DESCRIPTION
Hello @fhamborg,

I found that the ```SimpleCrawler.fetch_urls()``` in the NewsPlease main class doesn't take in the ```timeout``` variable. This leaves the ```requests.get()``` in ```SimpleCrawler``` to set its timeout to ```None```, which means the crawler will wait indefinitely until the connection is closed. This could be a problem if one of the inputted URLs fed into ```fetch_urls()``` never closes the connection: the ```get()``` will wait for the connection forever, and the entire crawling process hangs. 

Sample code:
```
from newsplease import NewsPlease

# news links from GDELT_v2
test_links = [
        'https://sputnikglobe.com/20231101/7-hostages-killed-in-bombing-of-jabalia-refugee-camp-on-tuesday--hamas-1114636769.html',
        'https://www.idahostatesman.com/news/politics-government/article281311593.html',  # Bad link.
        'https://www.newstribune.com/news/2023/nov/05/poppies-were-popular-saturday/'
]

articles = NewsPlease.from_urls(test_links, timeout = 10)
print(articles)
```

On the latest ```news-please```, this code will hang forever because the second link never actively closes the connection. After applying this patch, the sample code works with the following output:
```
connection/timeout error: https://www.idahostatesman.com/news/politics-government/article281311593.html HTTPSConnectionPool(host='www.idahostatesman.com', port=443): Read timed out. (read timeout=10)
{'https://www.newstribune.com/news/2023/nov/05/poppies-were-popular-saturday/': <NewsArticle.NewsArticle object at 0x7f7d040fbf90>, 'https://sputnikglobe.com/20231101/7-hostages-killed-in-bombing-of-jabalia-refugee-camp-on-tuesday--hamas-1114636769.html': <NewsArticle.NewsArticle object at 0x7f7d04108210>, 'https://www.idahostatesman.com/news/politics-government/article281311593.html': {}}
```