### PR TITLE
Use SPIDER_MODULES field from configuration file if it's defined

### DIFF
--- a/newsplease/single_crawler.py
+++ b/newsplease/single_crawler.py
@@ -49,7 +49,7 @@ class SingleCrawler(object):
     json_file_path = None
     cfg_crawler = None
     __scrapy_options = None
-    __crawer_module = "newsplease.crawler.spiders"
+    __default_spider_modules = "newsplease.crawler.spiders"
     site_number = None
     shall_resume = False
     daemonize = False
@@ -228,14 +228,17 @@ class SingleCrawler(object):
 
     def get_crawler_class(self, crawler):
         """
-        Searches through the modules in self.__crawer_module for a crawler with
+        Searches through the modules in spider_modules for a crawler with
         the name passed along.
 
         :param str crawler: Name of the crawler to load
         :rtype: crawler-class
         """
         settings = Settings()
-        settings.set('SPIDER_MODULES', [self.__crawer_module])
+        spider_modules = self.cfg.section("Scrapy").get(
+            "spider_modules", [self.__default_spider_modules]
+        )
+        settings.set("SPIDER_MODULES", spider_modules)
         spider_loader = SpiderLoader(settings)
         return spider_loader.load(crawler)
 


### PR DESCRIPTION
Hey @fhamborg 

Thank you for your work on news-please 🙇 

I've noticed that the `SPIDER_MODULE` field in the configuration files (section `Scrapy`) is not used at all during runtime. 
The spider modules used are forced to be the ones in news-please repository with the attribute `__crawer_module`.
Using it may allow us to use custom spiders if we need a specific treatment.

I also renamed the private attribute `__crawer_modules` to `__default_spider_modules` to be consistent with the field in the configuration file.