### PR TITLE
Allow RssCrawler to fallback if there was an empty RSS feed

### DIFF
--- a/newsplease/config/config.cfg
+++ b/newsplease/config/config.cfg
@@ -38,7 +38,8 @@ fallbacks = {
     }
 
 # Check that the crawler will analyze at least one URL during parse step
-should_check_crawler_has_urls_to_scan = False
+# In case the check fails, the next crawler in the pipeline will be used
+check_crawler_has_urls_to_scan = False
 
 # Determines how many hours need to pass since the last download of a webpage
 # to be downloaded again by the RssCrawler

--- a/newsplease/config/config.cfg
+++ b/newsplease/config/config.cfg
@@ -30,12 +30,15 @@ default = SitemapCrawler
 #     "Download": None
 #     }
 fallbacks = {
-    "RssCrawler": None,
+    "RssCrawler": "SitemapCrawler",
     "RecursiveSitemapCrawler": "RecursiveCrawler",
     "SitemapCrawler": "RecursiveCrawler",
     "RecursiveCrawler": None,
     "Download": None
     }
+
+# Check that the crawler will analyze at least one URL during parse step
+check_urls_during_fallback = False
 
 # Determines how many hours need to pass since the last download of a webpage
 # to be downloaded again by the RssCrawler

--- a/newsplease/config/config.cfg
+++ b/newsplease/config/config.cfg
@@ -38,7 +38,7 @@ fallbacks = {
     }
 
 # Check that the crawler will analyze at least one URL during parse step
-check_urls_during_fallback = False
+should_check_crawler_has_urls_to_scan = False
 
 # Determines how many hours need to pass since the last download of a webpage
 # to be downloaded again by the RssCrawler

--- a/newsplease/config/config.cfg
+++ b/newsplease/config/config.cfg
@@ -30,7 +30,7 @@ default = SitemapCrawler
 #     "Download": None
 #     }
 fallbacks = {
-    "RssCrawler": "SitemapCrawler",
+    "RssCrawler": None,
     "RecursiveSitemapCrawler": "RecursiveCrawler",
     "SitemapCrawler": "RecursiveCrawler",
     "RecursiveCrawler": None,

--- a/newsplease/config/config_lib.cfg
+++ b/newsplease/config/config_lib.cfg
@@ -44,7 +44,8 @@ fallbacks = {
     }
 
 # Check that the crawler will analyze at least one URL during parse step
-should_check_crawler_has_urls_to_scan = False
+# In case the check fails, the next crawler in the pipeline will be used
+check_crawler_has_urls_to_scan = False
 
 # Determines how many hours need to pass since the last download of a webpage
 # to be downloaded again by the RssCrawler

--- a/newsplease/config/config_lib.cfg
+++ b/newsplease/config/config_lib.cfg
@@ -43,6 +43,9 @@ fallbacks = {
     "Download": None
     }
 
+# Check that the crawler will analyze at least one URL during parse step
+should_check_crawler_has_urls_to_scan = False
+
 # Determines how many hours need to pass since the last download of a webpage
 # to be downloaded again by the RssCrawler
 # default: 6

--- a/newsplease/crawler/spiders/download_crawler.py
+++ b/newsplease/crawler/spiders/download_crawler.py
@@ -2,8 +2,10 @@ import logging
 
 import scrapy
 
+from newsplease.crawler.spiders.newsplease_spider import NewspleaseSpider
 
-class Download(scrapy.Spider):
+
+class Download(NewspleaseSpider, scrapy.Spider):
     name = "Download"
     start_urls = None
 

--- a/newsplease/crawler/spiders/gdelt_crawler.py
+++ b/newsplease/crawler/spiders/gdelt_crawler.py
@@ -1,3 +1,5 @@
+from newsplease.crawler.spiders.newsplease_spider import NewspleaseSpider
+
 try:
     import urllib2
 except ImportError:
@@ -16,7 +18,7 @@ import zipfile
 re_export = re.compile(r'.*?(http.*?export\.CSV\.zip)')
 
 
-class GdeltCrawler(scrapy.Spider):
+class GdeltCrawler(NewspleaseSpider, scrapy.Spider):
     name = "GdeltCrawler"
     ignored_allowed_domains = None
     start_urls = None

--- a/newsplease/crawler/spiders/newsplease_spider.py
+++ b/newsplease/crawler/spiders/newsplease_spider.py
@@ -1,0 +1,19 @@
+from abc import abstractmethod, ABC
+
+
+class NewspleaseSpider(ABC):
+    """
+    Abstract base class for newsplease spiders.
+    Defines methods that should be inherited by subclasses
+    """
+
+    @staticmethod
+    @abstractmethod
+    def supports_site(url: str) -> bool:
+        """
+        Determines if this spider works on the given URL.
+
+        :param str url: The url to test
+        :return bool:
+        """
+        pass

--- a/newsplease/crawler/spiders/newsplease_spider.py
+++ b/newsplease/crawler/spiders/newsplease_spider.py
@@ -17,3 +17,13 @@ class NewspleaseSpider(ABC):
         :return bool:
         """
         pass
+
+    @staticmethod
+    def has_urls_to_scan(url: str) -> bool:
+        """
+        Determines if this spider has any URLs to scan.
+
+        :param str url: The url to test
+        :return bool:
+        """
+        return True

--- a/newsplease/crawler/spiders/recursive_crawler.py
+++ b/newsplease/crawler/spiders/recursive_crawler.py
@@ -2,8 +2,10 @@ import logging
 
 import scrapy
 
+from newsplease.crawler.spiders.newsplease_spider import NewspleaseSpider
 
-class RecursiveCrawler(scrapy.Spider):
+
+class RecursiveCrawler(NewspleaseSpider, scrapy.Spider):
     name = "RecursiveCrawler"
     allowed_domains = None
     start_urls = None

--- a/newsplease/crawler/spiders/recursive_sitemap_crawler.py
+++ b/newsplease/crawler/spiders/recursive_sitemap_crawler.py
@@ -2,10 +2,12 @@ import logging
 
 import scrapy
 
-from ...helper_classes.url_extractor import UrlExtractor
+
+from newsplease.crawler.spiders.newsplease_spider import NewspleaseSpider
+from newsplease.helper_classes.url_extractor import UrlExtractor
 
 
-class RecursiveSitemapCrawler(scrapy.spiders.SitemapSpider):
+class RecursiveSitemapCrawler(NewspleaseSpider, scrapy.spiders.SitemapSpider):
     name = "RecursiveSitemapCrawler"
     allowed_domains = None
     sitemap_urls = None

--- a/newsplease/crawler/spiders/rss_crawler.py
+++ b/newsplease/crawler/spiders/rss_crawler.py
@@ -1,5 +1,7 @@
 from requests import get
-from scrapy.http import Request, TextResponse, XmlResponse
+from scrapy.http import TextResponse, XmlResponse
+
+from newsplease.crawler.spiders.newsplease_spider import NewspleaseSpider
 from newsplease.helper_classes.url_extractor import UrlExtractor
 
 try:
@@ -18,7 +20,7 @@ re_rss = re.compile(
 )
 
 
-class RssCrawler(scrapy.Spider):
+class RssCrawler(NewspleaseSpider, scrapy.Spider):
     name = "RssCrawler"
     ignored_allowed_domains = None
     start_urls = None

--- a/newsplease/crawler/spiders/rss_crawler.py
+++ b/newsplease/crawler/spiders/rss_crawler.py
@@ -117,18 +117,26 @@ class RssCrawler(NewspleaseSpider, scrapy.Spider):
         return re.search(re_rss, response.decode("utf-8")) is not None
 
     @staticmethod
-    def has_urls_to_scan(url):
-        """Check either the RSS feed contains any URL to scan"""
+    def has_urls_to_scan(url: str) -> bool:
+        """
+        Check if the RSS feed contains any URL to scan
+
+        :param str url: The url to test
+        :return bool:
+        """
         redirect_url = RssCrawler.get_potential_redirection_from_url(url)
+
         response = get(redirect_url)
         scrapy_response = TextResponse(url=redirect_url, body=response.text.encode())
+
         rss_url = UrlExtractor.get_rss_url(scrapy_response)
         rss_content = get(rss_url).text
-        print(rss_content)
         rss_response = XmlResponse(url=rss_url, body=rss_content, encoding="utf-8")
+
         urls_to_scan = [
             url
             for item in rss_response.xpath("//item")
             for url in item.xpath("link/text()").extract()
         ]
+
         return len(urls_to_scan) > 0

--- a/newsplease/crawler/spiders/sitemap_crawler.py
+++ b/newsplease/crawler/spiders/sitemap_crawler.py
@@ -2,10 +2,12 @@ import logging
 
 import scrapy
 
-from ...helper_classes.url_extractor import UrlExtractor
+
+from newsplease.crawler.spiders.newsplease_spider import NewspleaseSpider
+from newsplease.helper_classes.url_extractor import UrlExtractor
 
 
-class SitemapCrawler(scrapy.spiders.SitemapSpider):
+class SitemapCrawler(NewspleaseSpider, scrapy.spiders.SitemapSpider):
     name = "SitemapCrawler"
     allowed_domains = None
     sitemap_urls = None

--- a/newsplease/helper_classes/url_extractor.py
+++ b/newsplease/helper_classes/url_extractor.py
@@ -1,6 +1,7 @@
 """
 Helper class for url extraction.
 """
+
 import os
 import re
 from newsplease.config import CrawlerConfig
@@ -124,7 +125,8 @@ class UrlExtractor(object):
         # Check if "Sitemap" is set
         return "Sitemap:" in response.read().decode('utf-8')
 
-    def get_rss_url(self, response):
+    @staticmethod
+    def get_rss_url(response):
         """
         Extracts the rss feed's url from the scrapy response.
 

--- a/newsplease/single_crawler.py
+++ b/newsplease/single_crawler.py
@@ -196,7 +196,7 @@ class SingleCrawler(object):
         :param str url: the url this crawler is supposed to be loaded with
         :rtype: crawler-class or None
         """
-        should_check_crawler_has_urls_to_scan = self.cfg_crawler.get('should_check_crawler_has_urls_to_scan')
+        check_crawler_has_urls_to_scan = self.cfg_crawler.get('check_crawler_has_urls_to_scan')
 
         checked_crawlers = []
         while crawler is not None and crawler not in checked_crawlers:
@@ -214,7 +214,7 @@ class SingleCrawler(object):
                 crawler_supports_site = False
 
             if crawler_supports_site:
-                if should_check_crawler_has_urls_to_scan and not current.has_urls_to_scan(url):
+                if check_crawler_has_urls_to_scan and not current.has_urls_to_scan(url):
                     self.log.warning(f"Crawler {crawler} has no url to scan for {url}")
                 else:
                     self.log.debug("Using crawler %s for %s.", crawler, url)

--- a/newsplease/single_crawler.py
+++ b/newsplease/single_crawler.py
@@ -240,7 +240,7 @@ class SingleCrawler(object):
         :param str crawler: Name of the crawler to load
         :rtype: crawler-class
         """
-        spider_modules = self.cfg.section("Scrapy").get("SPIDER_MODULES", [self.__default_spider_modules])
+        spider_modules = self.cfg.section("Scrapy").get("spider_modules", [self.__default_spider_modules])
 
         settings = Settings()
         settings.set("SPIDER_MODULES", spider_modules)

--- a/newsplease/single_crawler.py
+++ b/newsplease/single_crawler.py
@@ -181,7 +181,7 @@ class SingleCrawler(object):
 
         self.__scrapy_options["JOBDIR"] = working_path + jobdirname + hashed.hexdigest()
 
-    def get_crawler(self, crawler, url):
+    def get_crawler(self, crawler, url, check_urls_for_crawler):
         """
         Checks if a crawler supports a website (the website offers e.g. RSS
         or sitemap) and falls back to the fallbacks defined in the config if
@@ -189,6 +189,8 @@ class SingleCrawler(object):
 
         :param str crawler: Crawler-string (from the crawler-module)
         :param str url: the url this crawler is supposed to be loaded with
+        :param str check_urls_for_crawler: Allow to fallback if the crawler is supported,
+        but don't have any URLs to scan
         :rtype: crawler-class or None
         """
         checked_crawlers = []
@@ -205,9 +207,10 @@ class SingleCrawler(object):
                                       exc_info=True)
                         crawler_supports_site = False
 
-                    if crawler_supports_site:
-                        self.log.debug("Using crawler %s for %s.",
-                                       crawler, url)
+                    if (
+                        crawler_supports_site
+                    ):  # TODO : Add URLs checks here with an option
+                        self.log.debug("Using crawler %s for %s.", crawler, url)
                         return current
                     elif (crawler in self.cfg_crawler["fallbacks"] and
                                   self.cfg_crawler["fallbacks"][crawler] is not None):


### PR DESCRIPTION
# Context

Sometimes, the RSS feed may be misconfigured, causing the crawling process to return empty results. We propose adding an option to fall back if the RSS feed is supported but empty.

# Feature

Add an option to the `RssCrawler` to fall back to another crawler if the RSS feed is supported but does not contain any articles.

# Changes

- Add an interface for news-please spiders
- Transform `get_rss_url` from `UrlExtractor` to static
- Add an option `should_check_crawler_has_urls_to_scan` in the configuration file to enable this feature. By default, it is set to `False` to preserve the current behavior