### PR TITLE
Cast get_max_url_file_name_length result to int

### DIFF
--- a/newsplease/helper_classes/savepath_parser.py
+++ b/newsplease/helper_classes/savepath_parser.py
@@ -313,7 +313,7 @@ class SavepathParser(object):
         max_size = 260 - 1 - size_without_max_url_file_name
         max_size_per_occurrence = max_size / number_occurrences
 
-        return max_size_per_occurrence
+        return int(max_size_per_occurrence)
 
     @staticmethod
     def get_filename(savepath):


### PR DESCRIPTION
A cast to an int is missing to the result of `get_max_url_file_name_length` function.
Since the division computation `max_size_per_occurrence = max_size / number_occurrences` will cast the str size to a float. 

Otherwise it may breaks the `append_md5_if_too_long` function since str slicing is done. I spotted this during an execution with large absolute path with the following error : 
```
  File "[...]/.venv/lib/python3.10/site-packages/newsplease/helper_classes/savepath_parser.py", line 99, in append_md5_if_too_long
    return "%s_%s" % (component[:component_size], hashlib.md5(component.encode("utf-8")).hexdigest())
```
Here `component_size` is a float and then is breaking the slicing