### PR TITLE
Add unique constraint on column `url` on table `CurrentVersions` in Postgres pipeline

### DIFF
--- a/newsplease/init-postgresql-db.sql
+++ b/newsplease/init-postgresql-db.sql
@@ -49,5 +49,6 @@ CREATE TABLE CurrentVersions (
   language varchar(255),
   ancestor int NOT NULL DEFAULT 0,
   descendant int NOT NULL DEFAULT 0,
-  version int NOT NULL DEFAULT 1
+  version int NOT NULL DEFAULT 1,
+  CONSTRAINT unique_url UNIQUE(url)
 );


### PR DESCRIPTION
Hello, we've noticed performances issues when running lots of urls with the Postgres pipeline.

We would like to add a unique constraint on `url` column since:
* the select query filtered on the url expects 0 or 1 row
* the unique constraint [will create a unique index](https://www.postgresql.org/docs/current/indexes-unique.html#:~:text=PostgreSQL%20automatically%20creates%20a%20unique,mechanism%20that%20enforces%20the%20constraint.) that helps a lot performance wise