### PR TITLE
Add Redis pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__/
 news-please.iml
 
 venv/
+.python-version
+build
+**.egg-info/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ news-please extracts the following attributes from news articles. An examplary j
 news-please supports three main use cases, which are explained in more detail in the following.
 
 #### CLI mode
-* stores extracted results in JSON files, PostgreSQL, ElasticSearch, or your own storage
+* stores extracted results in JSON files, PostgreSQL, ElasticSearch, Redis, or your own storage
 * simple but extensive configuration (if you want to tweak the results)
 * revisions: crawl articles multiple times and track changes
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ news-please allows to store articles on a Redis database, including the versioni
        'newsplease.pipeline.pipelines.RedisStorage':350
      }
 
-    [Reids]
+    [Redis]
     host = localhost
     port = 6379
     db = 0

--- a/README.md
+++ b/README.md
@@ -160,6 +160,26 @@ news-please allows for storing of articles to a PostgreSQL database, including t
 
 If you plan to use news-please and its export to PostgreSQL in a production environment, we recommend to uninstall the `psycopg2-binary` package and install `psycopg2`. We use the former since it does not require a C compiler in order to be installed. See [here](https://pypi.org/project/psycopg2-binary/), for more information on differences between `psycopg2` and `psycopg2-binary` and how to setup a production environment.
 
+### Redis
+news-please allows to store articles on a Redis database, including the versioning feature. To export to Redis, open the corresponding config file (`config_lib.cfg` for library mode and `config.cfg` for CLI mode) and add the RedisStorage module to the pipeline and adjust the connection credentials:
+
+    [Scrapy]
+    ITEM_PIPELINES = {
+       'newsplease.pipeline.pipelines.ArticleMasterExtractor':100,
+       'newsplease.pipeline.pipelines.RedisStorage':350
+     }
+
+    [Reids]
+    host = localhost
+    port = 6379
+    db = 0
+
+    # You can add any redis connection parameter here
+    ssl_check_hostname = True
+    username = "news-please"
+    max_connections = 24
+
+This pipeline should also be compatible with AWS Elasticache and GCP MemoryStore
 
 ### What's next?
 We have collected a bunch of useful information for both [users](https://github.com/fhamborg/news-please/wiki/user-guide)  and [developers](https://github.com/fhamborg/news-please/wiki/developer-guide). As a user, you will most likely only deal with two files: [`sitelist.hjson`](https://github.com/fhamborg/news-please/wiki/user-guide#sitelisthjson) (to define sites to be crawled) and [`config.cfg`](https://github.com/fhamborg/news-please/wiki/configuration) (probably only rarely, in case you want to tweak the configuration).

--- a/newsplease/__main__.py
+++ b/newsplease/__main__.py
@@ -5,13 +5,12 @@ import signal
 import sys
 import threading
 import time
-from copy import copy
 from distutils.dir_util import copy_tree
 from subprocess import Popen
 
 import plac
-import pymysql
 import psycopg2
+import pymysql
 from elasticsearch import Elasticsearch
 from scrapy.utils.log import configure_logging
 

--- a/newsplease/__main__.py
+++ b/newsplease/__main__.py
@@ -5,6 +5,7 @@ import signal
 import sys
 import threading
 import time
+from copy import copy
 from distutils.dir_util import copy_tree
 from subprocess import Popen
 
@@ -13,6 +14,8 @@ import pymysql
 import psycopg2
 from elasticsearch import Elasticsearch
 from scrapy.utils.log import configure_logging
+
+from .pipeline.pipelines import RedisStorageClient
 
 cur_path = os.path.dirname(os.path.realpath(__file__))
 par_path = os.path.dirname(cur_path)
@@ -53,6 +56,7 @@ class NewsPleaseLauncher(object):
     mysql = None
     postgresql = None
     elasticsearch = None
+    redis = None
     number_of_active_crawlers = 0
     config_directory_default_path = "~/news-please-repo/config/"
     config_file_default_name = "config.cfg"
@@ -61,7 +65,7 @@ class NewsPleaseLauncher(object):
     __single_crawler = False
 
     def __init__(self, cfg_directory_path, is_resume, is_reset_elasticsearch,
-        is_reset_json, is_reset_mysql, is_reset_postgresql, is_no_confirm, library_mode=False):
+        is_reset_json, is_reset_mysql, is_reset_postgresql, is_reset_redis, is_no_confirm, library_mode=False):
         """
         The constructor of the main class, thus the real entry point to the tool.
         :param cfg_file_path:
@@ -70,6 +74,7 @@ class NewsPleaseLauncher(object):
         :param is_reset_json:
         :param is_reset_mysql:
         :param is_reset_postgresql:
+        :param is_reset_redis:
         :param is_no_confirm:
         """
         configure_logging({"LOG_LEVEL": "ERROR"})
@@ -109,6 +114,7 @@ class NewsPleaseLauncher(object):
         self.mysql = self.cfg.section("MySQL")
         self.postgresql = self.cfg.section("Postgresql")
         self.elasticsearch = self.cfg.section("Elasticsearch")
+        self.redis = self.cfg.section("Redis")
 
         # perform reset if given as parameter
         if is_reset_mysql:
@@ -119,8 +125,10 @@ class NewsPleaseLauncher(object):
             self.reset_files()
         if is_reset_elasticsearch:
             self.reset_elasticsearch()
+        if is_reset_redis:
+            self.reset_redis()
         # close the process
-        if is_reset_elasticsearch or is_reset_json or is_reset_mysql or is_reset_postgresql:
+        if is_reset_elasticsearch or is_reset_json or is_reset_mysql or is_reset_postgresql or is_reset_redis:
             sys.exit(0)
 
         self.json_file_path = self.cfg_directory_path + self.cfg.section('Files')['url_input_file_name']
@@ -527,6 +535,48 @@ Cleanup files:
                 self.log.error("%s does not exist.", path)
             self.log.error(error)
 
+    def reset_redis(self):
+        """
+        Resets the redis cache.
+        """
+        print("""
+Cleanup Redis database:
+    This will flush collections.
+              """)
+
+        confirm = self.no_confirm
+
+        if not confirm:
+            confirm = "yes" in builtins.input(
+                """
+    Do you really want to do this? Write 'yes' to confirm: {yes}""".format(yes="yes" if confirm else "")
+            )
+
+        if not confirm:
+            print("Did not type yes. Thus aborting.")
+            return
+
+        redis_conn = copy(self.redis)
+
+        # Should the connection be allowed to flush the redis db?
+        # We assume News-please is not the only user of the redis instance.
+        _dangerously_flush_db = (
+            redis_conn.pop("dangerously_flush_db") if "dangerously_flush_db" in redis_conn else "false"
+        )
+        dangerously_flush_db = _dangerously_flush_db.lower() in ("1", "true")
+
+        connection = RedisStorageClient(
+            host=redis_conn.pop("host"),
+            port=int(redis_conn.pop("port")),
+            db=int(redis_conn.pop("db")),
+            health_check_interval=int(redis_conn.pop("health_check_interval"))
+            if "health_check_interval" in redis_conn
+            else 0,
+            dangerously_flush_db=dangerously_flush_db,
+            **redis_conn,
+        )
+        connection.purge()
+
     class CrawlerList(object):
         """
         Class that manages all crawlers that aren't supposed to be daemonized.
@@ -681,22 +731,43 @@ Cleanup files:
     reset_json=plac.Annotation('reset JSON files', 'flag'),
     reset_mysql=plac.Annotation('reset MySQL database', 'flag'),
     reset_postgresql=plac.Annotation('reset Postgresql database', 'flag'),
+    reset_redis=plac.Annotation('reset Redis database', 'flag'),
     reset_all=plac.Annotation('combines all reset options', 'flag'),
     no_confirm=plac.Annotation('skip confirm dialogs', 'flag')
 )
-def cli(cfg_file_path, resume, reset_elasticsearch, reset_mysql, reset_postgresql, reset_json, reset_all, no_confirm):
-    "A generic news crawler and extractor."
+def cli(
+    cfg_file_path,
+    resume,
+    reset_elasticsearch,
+    reset_json,
+    reset_mysql,
+    reset_postgresql,
+    reset_redis,
+    reset_all,
+    no_confirm,
+):
+    """A generic news crawler and extractor."""
 
     if reset_all:
         reset_elasticsearch = True
         reset_json = True
         reset_mysql = True
         reset_postgresql = True
+        reset_redis = True
 
     if cfg_file_path and not cfg_file_path.endswith(os.path.sep):
         cfg_file_path += os.path.sep
 
-    NewsPleaseLauncher(cfg_file_path, resume, reset_elasticsearch, reset_json, reset_mysql, reset_postgresql, no_confirm)
+    NewsPleaseLauncher(
+        cfg_file_path,
+        resume,
+        reset_elasticsearch,
+        reset_json,
+        reset_mysql,
+        reset_postgresql,
+        reset_redis,
+        no_confirm,
+    )
 
 
 def main():

--- a/newsplease/__main__.py
+++ b/newsplease/__main__.py
@@ -556,25 +556,7 @@ Cleanup Redis database:
             print("Did not type yes. Thus aborting.")
             return
 
-        redis_conn = copy(self.redis)
-
-        # Should the connection be allowed to flush the redis db?
-        # We assume News-please is not the only user of the redis instance.
-        _dangerously_flush_db = (
-            redis_conn.pop("dangerously_flush_db") if "dangerously_flush_db" in redis_conn else "false"
-        )
-        dangerously_flush_db = _dangerously_flush_db.lower() in ("1", "true")
-
-        connection = RedisStorageClient(
-            host=redis_conn.pop("host"),
-            port=int(redis_conn.pop("port")),
-            db=int(redis_conn.pop("db")),
-            health_check_interval=int(redis_conn.pop("health_check_interval"))
-            if "health_check_interval" in redis_conn
-            else 0,
-            dangerously_flush_db=dangerously_flush_db,
-            **redis_conn,
-        )
+        connection = RedisStorageClient.from_config_parser(self.cfg.parser)
         connection.purge()
 
     class CrawlerList(object):

--- a/newsplease/config/config.cfg
+++ b/newsplease/config/config.cfg
@@ -241,6 +241,20 @@ mapping = {"properties": {
     }}
 
 
+[Redis]
+
+# Redis required for saving meta-information
+host = localhost
+port = 6379
+database = 0
+
+# You can add any redis connection parameter here
+
+# Extra settings
+enable_archive = 'true'
+ttl = -1
+dangerously_flush_db = 'false'
+
 
 [ArticleMasterExtractor]
 

--- a/newsplease/config/config.cfg
+++ b/newsplease/config/config.cfg
@@ -246,14 +246,14 @@ mapping = {"properties": {
 # Redis required for saving meta-information
 host = localhost
 port = 6379
-database = 0
+db = 0
 
 # You can add any redis connection parameter here
 
 # Extra settings
-enable_archive = 'true'
+enable_archive = True
 ttl = -1
-dangerously_flush_db = 'false'
+dangerously_flush_db = False
 
 
 [ArticleMasterExtractor]

--- a/newsplease/config/config_lib.cfg
+++ b/newsplease/config/config_lib.cfg
@@ -247,6 +247,20 @@ mapping = {
     }
 
 
+[Redis]
+
+# Redis required for saving meta-information
+host = localhost
+port = 6379
+db = 0
+
+# You can add any redis connection parameter here
+
+# Extra settings
+enable_archive = True
+ttl = -1
+dangerously_flush_db = False
+
 
 [ArticleMasterExtractor]
 

--- a/newsplease/pipeline/pipelines.py
+++ b/newsplease/pipeline/pipelines.py
@@ -854,7 +854,7 @@ class RedisStorageClient(StrictRedis):
             "db": config_parser.getint("Redis", "db"),
             "password": config_parser.get("Redis", "password", fallback=None),
             "socket_timeout": config_parser.getfloat("Redis", "socket_timeout", fallback=None),
-            "socket_connect_timeout": config_parser.float("Redis", "socket_connect_timeout", fallback=None),
+            "socket_connect_timeout": config_parser.getfloat("Redis", "socket_connect_timeout", fallback=None),
             "socket_keepalive": config_parser.getboolean("Redis", "socket_keepalive", fallback=None),
             "socket_keepalive_options": config_parser.get("Redis", "socket_keepalive_options", fallback=None),
             "unix_socket_path": config_parser.get("Redis", "unix_socket_path", fallback=None),
@@ -920,6 +920,8 @@ class RedisStorageClient(StrictRedis):
         Depending on the value of decode_responses, response can be str or bytes, if any.
         """
         raw = self._get_raw_current_version(url)
+        if not raw:
+            return None
         return json.loads(lzma.decompress(raw))
 
     def save_item(
@@ -950,8 +952,8 @@ class RedisStorageClient(StrictRedis):
         else:
             full_scan = chain.from_iterable(
                 (
-                    self.scan_iter(match=f"^{Collections.CurrentVersions}{self.separator}"),
-                    self.scan_iter(match=f"^{Collections.ArchiveVersions}{self.separator}"),
+                    self.scan_iter(match=f"{Collections.CurrentVersions}{self.separator}*"),
+                    self.scan_iter(match=f"{Collections.ArchiveVersions}{self.separator}*"),
                 ),
             )
             full_scan_batched = iter(lambda: tuple(islice(full_scan, 100)), ())

--- a/newsplease/pipeline/pipelines.py
+++ b/newsplease/pipeline/pipelines.py
@@ -10,6 +10,7 @@ import os.path
 import sys
 import warnings
 from concurrent.futures import ThreadPoolExecutor
+from configparser import RawConfigParser
 from enum import Enum
 from itertools import islice, chain
 from typing import Optional, Dict, Any
@@ -839,16 +840,59 @@ class RedisStorageClient(StrictRedis):
     separator = "::"
 
     def __init__(self, *args, dangerously_flush_db: bool = False, **kwargs):
-        strict_redis_kwargs = {
-            k: v
-            for k, v in kwargs
-            if k in self.strict_redis_expected_params()
-        }
-        if "decode_responses" in strict_redis_kwargs:
+        if "decode_responses" in kwargs:
             warnings.warn("`decode_responses` must remain set to False for compression")
             kwargs["decode_responses"] = False
-        super().__init__(*args, **strict_redis_kwargs)
+        super().__init__(*args, **kwargs)
         self.dangerously_flush_db = dangerously_flush_db
+
+    @classmethod
+    def from_config_parser(cls, config_parser: RawConfigParser):
+        connection_kwargs = {
+            "host": config_parser.get("Redis", "host"),
+            "port": config_parser.getint("Redis", "port"),
+            "db": config_parser.getint("Redis", "db"),
+            "password": config_parser.get("Redis", "password", fallback=None),
+            "socket_timeout": config_parser.getfloat("Redis", "socket_timeout", fallback=None),
+            "socket_connect_timeout": config_parser.float("Redis", "socket_connect_timeout", fallback=None),
+            "socket_keepalive": config_parser.getboolean("Redis", "socket_keepalive", fallback=None),
+            "socket_keepalive_options": config_parser.get("Redis", "socket_keepalive_options", fallback=None),
+            "unix_socket_path": config_parser.get("Redis", "unix_socket_path", fallback=None),
+            "encoding": config_parser.get("Redis", "encoding", fallback="utf-8"),
+            "encoding_errors": config_parser.get("Redis", "encoding_errors", fallback="strict"),
+            "charset": config_parser.get("Redis", "charset", fallback=None),
+            "errors": config_parser.get("Redis", "errors", fallback=None),
+            "retry_on_timeout": config_parser.getboolean("Redis", "retry_on_timeout", fallback=False),
+            "retry_on_error": config_parser.get("Redis", "retry_on_error", fallback=None),
+            "ssl": config_parser.getboolean("Redis", "ssl", fallback=False),
+            "ssl_keyfile": config_parser.get("Redis", "ssl_keyfile", fallback=None),
+            "ssl_certfile": config_parser.get("Redis", "ssl_certfile", fallback=None),
+            "ssl_cert_reqs": config_parser.get("Redis", "ssl_cert_reqs", fallback="required"),
+            "ssl_ca_certs": config_parser.get("Redis", "ssl_ca_certs", fallback=None),
+            "ssl_ca_path": config_parser.get("Redis", "ssl_ca_path", fallback=None),
+            "ssl_ca_data": config_parser.get("Redis", "ssl_ca_data", fallback=None),
+            "ssl_check_hostname": config_parser.getboolean("Redis", "ssl_check_hostname", fallback=False),
+            "ssl_password": config_parser.get("Redis", "ssl_password", fallback=None),
+            "ssl_validate_ocsp": config_parser.getboolean("Redis", "ssl_validate_ocsp", fallback=False),
+            "ssl_validate_ocsp_stapled": config_parser.getboolean(
+                "Redis", "ssl_validate_ocsp_stapled", fallback=False,
+            ),
+            "ssl_ocsp_context": config_parser.get("Redis", "ssl_ocsp_context", fallback=None),
+            "ssl_ocsp_expected_cert": config_parser.get("Redis", "ssl_ocsp_expected_cert", fallback=None),
+            "ssl_min_version": config_parser.get("Redis", "ssl_min_version", fallback=None),
+            "ssl_ciphers": config_parser.get("Redis", "ssl_ciphers", fallback=None),
+            "max_connections": config_parser.getint("Redis", "max_connections", fallback=None),
+            "single_connection_client": config_parser.getboolean("Redis", "single_connection_client", fallback=False),
+            "health_check_interval": config_parser.getint("Redis", "health_check_interval", fallback=0),
+            "client_name": config_parser.get("Redis", "client_name", fallback=None),
+            "username": config_parser.get("Redis", "username", fallback=None),
+            "retry": config_parser.get("Redis", "retry", fallback=None),
+            "redis_connect_func": config_parser.get("Redis", "redis_connect_func", fallback=None),
+            "credential_provider": config_parser.get("Redis", "credential_provider", fallback=None),
+            "protocol": config_parser.getint("Redis", "protocol", fallback=None),
+            "dangerously_flush_db": config_parser.getboolean("Redis", "dangerously_flush_db", fallback=False),
+        }
+        return cls(**connection_kwargs)
 
     @classmethod
     def strict_redis_expected_params(cls) -> set[str]:
@@ -933,32 +977,19 @@ class RedisStorage(ExtractedInformationStorage):
     def __init__(self):
         super().__init__()
 
-        redis_config = self.cfg.section("Redis")
+        # Establish redis connection
+        # Closing of the connection is handled once the spider closes
+        self.conn = RedisStorageClient.from_config_parser(self.cfg.parser)
 
         # No expiration by default
-        self.ttl = float(redis_config.pop("ttl")) if "ttl" in redis_config else None
+        self.ttl = self.cfg.parser.getfloat("Redis", "ttl", fallback=-1.0)
 
         # Sanity check
         if self.ttl < 1:
             self.ttl = None
 
         # Capability to avoid storing archives - default is True
-        _enable_archive = redis_config.pop("enable_archive") if "enable_archive" in redis_config else "true"
-        self.enable_archive = _enable_archive.lower() in ("1", "true")
-
-        # Establish redis connection
-        # Closing of the connection is handled once the spider closes
-        self.conn = RedisStorageClient(
-            host=redis_config.pop("host"),
-            port=int(redis_config.pop("port")),
-            db=int(redis_config.pop("db")),
-            health_check_interval=int(redis_config.pop("health_check_interval"))
-            if "health_check_interval" in redis_config
-            else 0,
-            **redis_config,
-        )
-
-        self.compression = lzma
+        self.enable_archive = self.cfg.parser.getboolean("Redis", "enable_archive", fallback=True)
 
     def process_item(self, item: Any, spider: scrapy.Spider):
         # get the original url, so that the library class (or whoever wants to read this) can access the article

--- a/newsplease/pipeline/pipelines.py
+++ b/newsplease/pipeline/pipelines.py
@@ -992,7 +992,7 @@ class RedisStorage(ExtractedInformationStorage):
         self.conn = RedisStorageClient.from_config_parser(self.cfg.parser)
 
         # No expiration by default
-        self.ttl = self.cfg.parser.getfloat("Redis", "ttl", fallback=-1.0)
+        self.ttl = self.cfg.parser.getint("Redis", "ttl", fallback=-1.0)
 
         # Sanity check
         if self.ttl < 1:

--- a/newsplease/pipeline/pipelines.py
+++ b/newsplease/pipeline/pipelines.py
@@ -942,8 +942,8 @@ class RedisStorageClient(StrictRedis):
 
     def purge(self):
         """
-        Performing the purge through a full scan on the 2 collections.
-        We assume, as it is done for the Postgres pipeline, that the client may have other objects stored on redis.
+        Empty the database.
+        Either a flushdb is performed or a scan+delete batched in the case of a shared database.
         """
 
         if self.dangerously_flush_db:
@@ -956,7 +956,7 @@ class RedisStorageClient(StrictRedis):
                     self.scan_iter(match=f"{Collections.ArchiveVersions}{self.separator}*"),
                 ),
             )
-            full_scan_batched = iter(lambda: tuple(islice(full_scan, 100)), ())
+            full_scan_batched = iter(lambda: tuple(islice(full_scan, 1000)), ())
 
             def partial(names: tuple[str, ...]):
                 self.delete(*names)

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ news-please is an open source, easy-to-use news crawler that extracts structured
           'hurry.filesize>=0.9',
           'bs4',
           'faust-cchardet>=2.1.18',
-          'boto3'
+          'boto3',
+          'redis',
       ],
       extras_require={
           ':sys_platform == "win32"': [


### PR DESCRIPTION
# Add Redis / Elasticache / MemoryStore storage pipeline

Implementation choices:
* 2 collections: "CurrentVersions", and "ArchiveVersions" in order to stay to what has been done for Postgres
* For faster lookups, we use keys of that form: key = { collection name } + { separator } + { identifier }
* LZMA compression for values
* Safe to store objects not related to news-please in the same db
* Possible to set a TTL on objects stored
* Possible to disable the archive

Tests performed with a local Redis and an Elasticache Redis