### PR TITLE
Add an additional sitemap check in Sitemap crawlers

### DIFF
--- a/newsplease/config/config.cfg
+++ b/newsplease/config/config.cfg
@@ -80,6 +80,21 @@ ignore_regex = "(mail[tT]o)|([jJ]avascript)|(tel)|(fax)"
 # default: True
 sitemap_allow_subdomains = True
 
+# Set of sitemap patterns
+# Allow to force the check of specific sitemaps if it's absent from robots.txt. 
+# Here is an example of definition:
+# sitemap_patterns = [
+#   "sitemap.xml",
+#   "post-sitemap.xml",
+#   "blog-posts-sitemap.xml",
+#   "sitemaps/post-sitemap.xml",
+#   "sitemap_index.xml",
+#   "sitemaps/sitemap_index.xml",
+#   "sitemaps/sitemap.xml",
+#   "sitemaps/sitemap-articles.xml"
+#   ]
+# default: [] which means there will be no sitemap check
+sitemap_patterns = []
 
 
 [Heuristics]

--- a/newsplease/crawler/spiders/recursive_sitemap_crawler.py
+++ b/newsplease/crawler/spiders/recursive_sitemap_crawler.py
@@ -28,16 +28,16 @@ class RecursiveSitemapCrawler(NewspleaseSpider, scrapy.spiders.SitemapSpider):
         self.helper = helper
 
         self.ignore_regex = ignore_regex
-        self.ignore_file_extensions = self.config.section(
-            'Crawler')['ignore_file_extensions']
+        self.ignore_file_extensions = self.config.section("Crawler")[
+            "ignore_file_extensions"
+        ]
 
         self.original_url = url
 
-        self.allowed_domains = [self.helper.url_extractor
-                                    .get_allowed_domain(url)]
-        self.sitemap_urls = [self.helper.url_extractor.get_sitemap_url(
-            url, config.section('Crawler')['sitemap_allow_subdomains'])]
-
+        self.allowed_domains = [self.helper.url_extractor.get_allowed_domain(url)]
+        self.sitemap_urls = self.helper.url_extractor.get_sitemap_urls(
+            url, config.section("Crawler")["sitemap_allow_subdomains"]
+        )
         super(RecursiveSitemapCrawler, self).__init__(*args, **kwargs)
 
     def parse(self, response):
@@ -50,13 +50,14 @@ class RecursiveSitemapCrawler(NewspleaseSpider, scrapy.spiders.SitemapSpider):
         if not self.helper.parse_crawler.content_type(response):
             return
 
-        for request in self.helper.parse_crawler \
-                .recursive_requests(response, self, self.ignore_regex,
-                                    self.ignore_file_extensions):
+        for request in self.helper.parse_crawler.recursive_requests(
+            response, self, self.ignore_regex, self.ignore_file_extensions
+        ):
             yield request
 
         yield self.helper.parse_crawler.pass_to_pipeline_if_article(
-            response, self.allowed_domains[0], self.original_url)
+            response, self.allowed_domains[0], self.original_url
+        )
 
     @staticmethod
     def supports_site(url):

--- a/newsplease/crawler/spiders/sitemap_crawler.py
+++ b/newsplease/crawler/spiders/sitemap_crawler.py
@@ -25,11 +25,14 @@ class SitemapCrawler(NewspleaseSpider, scrapy.spiders.SitemapSpider):
         self.helper = helper
         self.original_url = url
 
-        self.allowed_domains = [self.helper.url_extractor
-                                    .get_allowed_domain(url, config.section(
-            'Crawler')['sitemap_allow_subdomains'])]
-        self.sitemap_urls = [self.helper.url_extractor.get_sitemap_url(
-            url, config.section('Crawler')['sitemap_allow_subdomains'])]
+        self.allowed_domains = [
+            self.helper.url_extractor.get_allowed_domain(
+                url, config.section("Crawler")["sitemap_allow_subdomains"]
+            )
+        ]
+        self.sitemap_urls = self.helper.url_extractor.get_sitemap_urls(
+            url, config.section("Crawler")["sitemap_allow_subdomains"]
+        )
 
         self.log.debug(self.sitemap_urls)
 
@@ -46,7 +49,8 @@ class SitemapCrawler(NewspleaseSpider, scrapy.spiders.SitemapSpider):
             return
 
         yield self.helper.parse_crawler.pass_to_pipeline_if_article(
-            response, self.allowed_domains[0], self.original_url)
+            response, self.allowed_domains[0], self.original_url
+        )
 
     @staticmethod
     def only_extracts_articles():

--- a/newsplease/helper_classes/url_extractor.py
+++ b/newsplease/helper_classes/url_extractor.py
@@ -150,7 +150,7 @@ class UrlExtractor(object):
         if robots_response and robots_response.getcode() == 200:
             # Check if "Sitemap" is set
             return "Sitemap:" in robots_response.read().decode("utf-8")
-        # Check if there is an existing sitemap, outside from robots.txt
+        # Check if there is an existing sitemap outside of robots.txt
         sitemap_urls = UrlExtractor.check_sitemap_urls(domain_url=url)
         any_sitemap_found = len(sitemap_urls) > 0
         if not any_sitemap_found:

--- a/newsplease/helper_classes/url_extractor.py
+++ b/newsplease/helper_classes/url_extractor.py
@@ -86,7 +86,7 @@ class UrlExtractor(object):
 
     @staticmethod
     def check_sitemap_urls(domain_url: str) -> list[str]:
-        """Check if a set of sitemap exists for the requested domain"""
+        """Check if a set of sitemaps exists for the requested domain"""
         working_sitemap_paths = []
         for sitemap_path in SITEMAP_PATTERNS:
             # check common patterns

--- a/newsplease/helper_classes/url_extractor.py
+++ b/newsplease/helper_classes/url_extractor.py
@@ -5,6 +5,7 @@ Helper class for url extraction.
 import logging
 import os
 import re
+from scrapy.http import Response
 from http.client import HTTPResponse
 from urllib.error import URLError
 from newsplease.config import CrawlerConfig
@@ -45,7 +46,7 @@ class UrlExtractor(object):
     """
 
     @staticmethod
-    def get_allowed_domain(url, allow_subdomains=True):
+    def get_allowed_domain(url: str, allow_subdomains: bool = True) -> str:
         """
         Determines the url's domain.
 
@@ -59,7 +60,7 @@ class UrlExtractor(object):
             return re.search(re_domain, UrlExtractor.get_allowed_domain(url)).group(0)
 
     @staticmethod
-    def get_subdomain(url):
+    def get_subdomain(url: str) -> str:
         """
         Determines the domain's subdomains.
 
@@ -168,7 +169,7 @@ class UrlExtractor(object):
         return UrlExtractor.check_sitemap_urls(domain_url=domain_url)
 
     @staticmethod
-    def get_rss_url(response) -> str:
+    def get_rss_url(response: Response) -> str:
         """
         Extracts the rss feed's url from the scrapy response.
 
@@ -194,7 +195,7 @@ class UrlExtractor(object):
         return "http://" + UrlExtractor.get_allowed_domain(url) + "/"
 
     @staticmethod
-    def get_url_directory_string(url):
+    def get_url_directory_string(url: str) -> str:
         """
         Determines the url's directory string.
 
@@ -210,8 +211,8 @@ class UrlExtractor(object):
         # index = [index for index in range(len(splitted_url))
         #          if not re.search(domain, splitted_url[index]) is None][0]
         for index in range(len(splitted_url)):
-            if not re.search(domain, splitted_url[index]) is None:
-                if splitted_url[-1] is "":
+            if re.search(domain, splitted_url[index]) is not None:
+                if splitted_url[-1] == "":
                     splitted_url = splitted_url[index + 1 : -2]
                 else:
                     splitted_url = splitted_url[index + 1 : -1]
@@ -220,7 +221,7 @@ class UrlExtractor(object):
         return "_".join(splitted_url)
 
     @staticmethod
-    def get_url_file_name(url):
+    def get_url_file_name(url: str) -> str:
         """
         Determines the url's file name.
 

--- a/newsplease/helper_classes/url_extractor.py
+++ b/newsplease/helper_classes/url_extractor.py
@@ -2,14 +2,17 @@
 Helper class for url extraction.
 """
 
+import logging
+import http
 import os
 import re
+from urllib.error import URLError
 from newsplease.config import CrawlerConfig
 
 try:
-    from urlparse import urlparse
+    from urlparse import urljoin, urlparse
 except ImportError:
-    from urllib.parse import urlparse
+    from urllib.parse import urljoin, urlparse
 
 try:
     import urllib2
@@ -19,9 +22,21 @@ except ImportError:
 # len(".markdown") = 9
 MAX_FILE_EXTENSION_LENGTH = 9
 
+# Set of sitemap patterns
+SITEMAP_PATTERNS = [
+    "sitemap.xml",
+    "post-sitemap.xml",
+    "blog-posts-sitemap.xml",
+    "sitemaps/post-sitemap.xml",
+    "sitemap_index.xml",
+    "sitemaps/sitemap_index.xml",
+    "sitemaps/sitemap.xml",
+    "sitemaps/sitemap-articles.xml",
+]
+
 # to improve performance, regex statements are compiled only once per module
-re_www = re.compile(r'^(www.)')
-re_domain = re.compile(r'[^/.]+\.[^/.]+$', )
+re_www = re.compile(r"^(www.)")
+re_domain = re.compile(r"[^/.]+\.[^/.]+$")
 
 
 class UrlExtractor(object):
@@ -39,7 +54,7 @@ class UrlExtractor(object):
         :return str: subdomains.domain.topleveldomain or domain.topleveldomain
         """
         if allow_subdomains:
-            return re.sub(re_www, '', re.search(r'[^/]+\.[^/]+', url).group(0))
+            return re.sub(re_www, "", re.search(r"[^/]+\.[^/]+", url).group(0))
         else:
             return re.search(re_domain, UrlExtractor.get_allowed_domain(url)).group(0)
 
@@ -52,8 +67,9 @@ class UrlExtractor(object):
         :return str: subdomains of url
         """
         allowed_domain = UrlExtractor.get_allowed_domain(url)
-        return allowed_domain[:len(allowed_domain) - len(
-            UrlExtractor.get_allowed_domain(url, False))]
+        return allowed_domain[
+            : len(allowed_domain) - len(UrlExtractor.get_allowed_domain(url, False))
+        ]
 
     @staticmethod
     def follow_redirects(url):
@@ -68,7 +84,26 @@ class UrlExtractor(object):
         return opener.open(url).url
 
     @staticmethod
-    def get_sitemap_url(url, allow_subdomains):
+    def check_sitemap_urls(domain_url: str) -> list[str]:
+        """Check if a set of sitemap exists for the requested domain"""
+        working_sitemap_paths = []
+        for sitemap_path in SITEMAP_PATTERNS:
+            # check common patterns
+            url_sitemap = urljoin(domain_url, sitemap_path)
+            request = UrlExtractor.url_to_request_with_agent(url_sitemap)
+            try:
+                response = urllib2.urlopen(request)
+                if response.status_code == 200:
+                    working_sitemap_paths.append(url_sitemap)
+            except URLError:
+                continue
+
+        return working_sitemap_paths
+
+    @staticmethod
+    def get_robots_response(
+        url: str, allow_subdomains: bool
+    ) -> http.client.HTTPResponse:
         """
         Determines the domain's robot.txt
 
@@ -78,39 +113,31 @@ class UrlExtractor(object):
         :return: the robot.txt's address
         :raises Exception: if there's no robot.txt on the site's domain
         """
-        if allow_subdomains:
-            redirect = UrlExtractor.follow_redirects(
-                "http://" + UrlExtractor.get_allowed_domain(url)
-            )
-        else:
-            redirect = UrlExtractor.follow_redirects(
-                "http://" +
-                UrlExtractor.get_allowed_domain(url, False)
-            )
-        redirect = UrlExtractor.follow_redirects(url)
+        redirect_url = UrlExtractor.follow_redirects(
+            url="http://"
+            + UrlExtractor.get_allowed_domain(url, allow_subdomains=allow_subdomains),
+        )
 
         # Get robots.txt
-        parsed = urlparse(redirect)
+        parsed = urlparse(redirect_url)
         if allow_subdomains:
             url_netloc = parsed.netloc
         else:
-            url_netloc = UrlExtractor.get_allowed_domain(
-                parsed.netloc, False)
+            url_netloc = UrlExtractor.get_allowed_domain(parsed.netloc, False)
 
-        robots = '{url.scheme}://{url_netloc}/robots.txt'.format(
-            url=parsed, url_netloc=url_netloc)
-        robots_req = UrlExtractor.url_to_request_with_agent(robots)
-        try:
-            urllib2.urlopen(robots_req)
-            return robots
-        except:
-            if allow_subdomains:
-                return UrlExtractor.get_sitemap_url(url, False)
-            else:
-                raise Exception('Fatal: no robots.txt found.')
+        robots_url = "{url.scheme}://{url_netloc}/robots.txt".format(
+            url=parsed, url_netloc=url_netloc
+        )
+        robots_req = UrlExtractor.url_to_request_with_agent(robots_url)
+        response = urllib2.urlopen(robots_req)
+        if response.status_code == 200:
+            return response
+        if allow_subdomains:
+            return UrlExtractor.get_robots_response(url=url, allow_subdomains=False)
+        return response
 
     @staticmethod
-    def sitemap_check(url):
+    def sitemap_check(url: str) -> bool:
         """
         Sitemap-Crawler are supported by every site which have a
         Sitemap set in the robots.txt.
@@ -118,15 +145,31 @@ class UrlExtractor(object):
         :param str url: the url to work on
         :return bool: Determines if Sitemap is set in the site's robots.txt
         """
-        url = UrlExtractor.get_sitemap_url(url, True)
-        url = UrlExtractor.url_to_request_with_agent(url)
-        response = urllib2.urlopen(url)
-
-        # Check if "Sitemap" is set
-        return "Sitemap:" in response.read().decode('utf-8')
+        robots_response = UrlExtractor.get_robots_response(
+            url=url, allow_subdomains=True
+        )
+        if robots_response.status_code == 200:
+            # Check if "Sitemap" is set
+            return "Sitemap:" in robots_response.read().decode("utf-8")
+        # Check if there is an existing sitemap, outside from robots.txt
+        sitemap_urls = UrlExtractor.check_sitemap_urls(domain_url=url)
+        any_sitemap_found = len(sitemap_urls) > 0
+        if not any_sitemap_found:
+            logging.warning("Fatal: no robots.txt nor sitemap found.")
+        return any_sitemap_found
 
     @staticmethod
-    def get_rss_url(response):
+    def get_sitemap_urls(domain_url: str, allow_subdomains: bool) -> list[str]:
+        """Retrieve SitemapCrawler file inputs from robots or sitemaps"""
+        robots_response = UrlExtractor.get_robots_response(
+            url=domain_url, allow_subdomains=allow_subdomains
+        )
+        if robots_response.status_code == 200:
+            return [robots_response.url]
+        return UrlExtractor.check_sitemap_urls(domain_url=domain_url)
+
+    @staticmethod
+    def get_rss_url(response) -> str:
         """
         Extracts the rss feed's url from the scrapy response.
 
@@ -136,13 +179,13 @@ class UrlExtractor(object):
         # if this throws an IndexError, then the webpage with the given url
         # does not contain a link of type "application/rss+xml"
         return response.urljoin(
-            response.xpath(
-                '//link[contains(@type, "application/rss+xml")]'
-            ).xpath('@href').extract()[0]
+            response.xpath('//link[contains(@type, "application/rss+xml")]')
+            .xpath("@href")
+            .extract()[0]
         )
 
     @staticmethod
-    def get_start_url(url):
+    def get_start_url(url: str) -> str:
         """
         Determines the start url to start a crawler from
 
@@ -161,7 +204,7 @@ class UrlExtractor(object):
         """
         domain = UrlExtractor.get_allowed_domain(url)
 
-        splitted_url = url.split('/')
+        splitted_url = url.split("/")
 
         # the following commented list comprehension could replace
         # the following for, if not and break statement
@@ -170,12 +213,12 @@ class UrlExtractor(object):
         for index in range(len(splitted_url)):
             if not re.search(domain, splitted_url[index]) is None:
                 if splitted_url[-1] is "":
-                    splitted_url = splitted_url[index + 1:-2]
+                    splitted_url = splitted_url[index + 1 : -2]
                 else:
-                    splitted_url = splitted_url[index + 1:-1]
+                    splitted_url = splitted_url[index + 1 : -1]
                 break
 
-        return '_'.join(splitted_url)
+        return "_".join(splitted_url)
 
     @staticmethod
     def get_url_file_name(url):
@@ -193,7 +236,7 @@ class UrlExtractor(object):
             return os.path.split(url)[1]
 
     @staticmethod
-    def url_to_request_with_agent(url):
+    def url_to_request_with_agent(url: str) -> urllib2.Request:
         options = CrawlerConfig.get_instance().get_scrapy_options()
-        user_agent = options['USER_AGENT']
-        return urllib2.Request(url, headers={'user-agent': user_agent})
+        user_agent = options["USER_AGENT"]
+        return urllib2.Request(url, headers={"user-agent": user_agent})

--- a/newsplease/helper_classes/url_extractor.py
+++ b/newsplease/helper_classes/url_extractor.py
@@ -86,7 +86,11 @@ class UrlExtractor(object):
 
     @staticmethod
     def check_sitemap_urls(domain_url: str) -> list[str]:
-        """Check if a set of sitemaps exists for the requested domain"""
+        """Check if a set of sitemaps exists for the requested domain
+
+        :param str domain_url: The URL to work on
+        :return list[str] working_sitemap_paths: All available sitemap for the domain_url
+        """
         working_sitemap_paths = []
         for sitemap_path in SITEMAP_PATTERNS:
             # check common patterns
@@ -104,12 +108,12 @@ class UrlExtractor(object):
     @staticmethod
     def get_robots_response(url: str, allow_subdomains: bool) -> HTTPResponse | None:
         """
-        Retrieve robots.txt if it exists
+        Retrieve robots.txt response if it exists
 
         :param str url: the url to work on
         :param bool allow_subdomains: Determines if the robot.txt may be the
                                       subdomain's
-        :return: the robot.txt's HTTP response
+        :return: the robot.txt's HTTP response or None if it's not retrieved
         """
         redirect_url = UrlExtractor.follow_redirects(
             url="http://"
@@ -160,7 +164,13 @@ class UrlExtractor(object):
 
     @staticmethod
     def get_sitemap_urls(domain_url: str, allow_subdomains: bool) -> list[str]:
-        """Retrieve SitemapCrawler input URLs from robots.txt or sitemaps"""
+        """Retrieve SitemapCrawler input URLs from robots.txt or sitemaps
+
+        :param str domain_url: The URL to work on
+        :param bool allow_subdomains: Determines if the robot.txt may be the
+            subdomain's
+        :return list[str]: robots.txt URL or available sitemaps
+        """
         robots_response = UrlExtractor.get_robots_response(
             url=domain_url, allow_subdomains=allow_subdomains
         )


### PR DESCRIPTION
Hey,

We've noticed that some `robots.txt` files don't reference any sitemaps, even though sitemaps exist on the website.

I propose an additional check during the `support_site` method in sitemap crawlers (SitemapCrawler and RecursiveSitemapCrawler) that will loop over a set of commonly used sitemaps to check for articles.

A new parameter is available `sitemap_patterns` in the configuration file that allows to ping a set of sitemaps in addition of `robots.txt` existence check

# Changes
- Add a set of common sitemaps that will be checked during `support_site` step
- Rename and update `get_sitemap_url` function to `get_robots_response` since the requesting may be duplicated over 2 functions.
  - It doesn't raise anymore but only returns a boolean
- Add some typing