### PR TITLE
Fix type annotations for earlier Python versions

### DIFF
--- a/newsplease/helper_classes/url_extractor.py
+++ b/newsplease/helper_classes/url_extractor.py
@@ -5,6 +5,7 @@ Helper class for url extraction.
 import logging
 import os
 import re
+from typing import Optional
 from scrapy.http import Response
 from http.client import HTTPResponse
 from urllib.error import URLError
@@ -61,7 +62,7 @@ class UrlExtractor(object):
         ]
 
     @staticmethod
-    def follow_redirects(url):
+    def follow_redirects(url: str) -> str:
         """
         Get's the url actual address by following forwards
 
@@ -98,7 +99,7 @@ class UrlExtractor(object):
         return working_sitemap_paths
 
     @staticmethod
-    def get_robots_response(url: str, allow_subdomains: bool) -> HTTPResponse | None:
+    def get_robots_response(url: str, allow_subdomains: bool) -> Optional[HTTPResponse]:
         """
         Retrieve robots.txt response if it exists
 


### PR DESCRIPTION
Hey @fhamborg ,

Some code from my previous [PR](https://github.com/fhamborg/news-please/pull/271) contains modern typing, such as the `|` character which denotes a specific type OR another, introduced in [Python 3.10](https://peps.python.org/pep-0604/).
I adapted the code to use a more portable solution.

Sorry about this, it may affect people running news-please with Python versions earlier than 3.10