### PR TITLE
Add robustness for pages missing title

### DIFF
--- a/newsplease/helper_classes/parse_crawler.py
+++ b/newsplease/helper_classes/parse_crawler.py
@@ -66,8 +66,8 @@ class ParseCrawler(object):
         article['download_date'] = timestamp
         article['source_domain'] = source_domain.encode("utf-8")
         article['url'] = response.url
-        article['html_title'] = response.selector.xpath('//title/text()') \
-            .extract_first().encode("utf-8")
+        extracted_title = response.selector.xpath('//title/text()').extract_first()
+        article['html_title'] = extracted_title.encode("utf-8") if extracted_title is not None else ''
         if rss_title is None:
             article['rss_title'] = 'NULL'
         else:


### PR DESCRIPTION
Hello @fhamborg 
This pull request aims to add a bit of robustness, when a website doesn't use a title on some pages

```
    File "/usr/local/lib/python3.10/site-packages/newsplease/helper_classes/parse_crawler.py", line 43, in pass_to_pipeline_if_article
     return self.pass_to_pipeline(
   File "/usr/local/lib/python3.10/site-packages/newsplease/helper_classes/parse_crawler.py", line 70, in pass_to_pipeline
     .extract_first().encode("utf-8")
 AttributeError: 'NoneType' object has no attribute 'encode'
```