### PR TITLE
Remove typing_extensions.cast

### DIFF
--- a/newsplease/pipeline/pipelines.py
+++ b/newsplease/pipeline/pipelines.py
@@ -14,7 +14,7 @@ from configparser import RawConfigParser
 from enum import Enum
 from itertools import islice, chain
 from typing import Optional, Dict, Any
-from typing_extensions import TypedDict, cast
+from typing_extensions import TypedDict
 
 import scrapy
 
@@ -1029,7 +1029,7 @@ class RedisStorage(ExtractedInformationStorage):
             new_version_tag["__ancestor"] = old_version["__version"]
 
         # Add the new version of the article to the CurrentVersion table
-        new_version = cast(dict[str, Any], ExtractedInformationStorage.extract_relevant_info(item))
+        new_version = ExtractedInformationStorage.extract_relevant_info(item)
         new_version = {**new_version, **new_version_tag}
 
         # If an old version existed, this replaces it

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ hurry.filesize>=0.9
 bs4
 faust-cchardet>=2.1.18
 boto3
+typing-extensions>=4.3.0

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ news-please is an open source, easy-to-use news crawler that extracts structured
           'redis',
           'newspaper4k>=0.9.3.1',
           'lxml-html-clean>=0.1.1',
+          'typing-extensions>=4.3.0',
       ],
       extras_require={
           ':sys_platform == "win32"': [


### PR DESCRIPTION
Second possible solution to #275.

Removes using `cast()`, introduced in 8e95c71. It's for type checking only and not needed anyway (as far as I can tell). Makes #276 redundant.