### PR TITLE
Fix article_extractor to only instantiate the Extractors in the specified file

### DIFF
--- a/newsplease/pipeline/extractor/article_extractor.py
+++ b/newsplease/pipeline/extractor/article_extractor.py
@@ -18,6 +18,7 @@ class Extractor:
 
         :param extractor_list: List of strings containing all extractors to be initialized.
         """
+
         def proc_instance(instance):
             if instance is not None:
                 self.log.info('Extractor initialized: %s', extractor)
@@ -35,15 +36,19 @@ class Extractor:
             else:
                 extractor_module = extractor
 
-            module = importlib.import_module(__package__ + '.extractors.' + extractor_module)
+            module_name = __package__ + '.extractors.' + extractor_module
+            module = importlib.import_module(module_name)
 
             if isinstance(extractor, tuple):
                 proc_instance(getattr(module, extractor[1], None)())
             else:
-                # check module for subclasses of AbstractExtractor
+                # check in the current module for subclasses of AbstractExtractor
                 for member in inspect.getmembers(module, inspect.isclass):
-                    if issubclass(member[1], AbstractExtractor) and member[0] != 'AbstractExtractor':
-
+                    if (
+                        member[1].__module__ == module_name
+                        and issubclass(member[1], AbstractExtractor)
+                        and member[0] != 'AbstractExtractor'
+                    ):
                         # instantiate extractor
                         proc_instance(getattr(module, member[0], None)())
 


### PR DESCRIPTION
Hi @fhamborg, hope you are good !

Here is a bug fix for the `newspaper_extractor_no_images`

This is what I have in my config file
```
[ArticleMasterExtractor]
extractors = ['newspaper_extractor_no_images', 'readability_extractor', 'date_extractor', 'lang_detect_extractor']
```
And you can see in the screenshot the list of extractors that are actually instantiated contains `newspaper_extractor`
![image](https://github.com/user-attachments/assets/8038c96b-22ed-4da9-a716-a7285f1c0d6e)
This leads to unwanted behaviour since we are actually fetching images and doing twice the work by `newspaper_extractor` and `newspaper_extractor_no_images`

Tell me if you have any question