### PR TITLE
Add check_certificate option in configuration to be able to crawl sites not having a valid certificate

### DIFF
--- a/newsplease/__main__.py
+++ b/newsplease/__main__.py
@@ -14,7 +14,7 @@ import pymysql
 from elasticsearch import Elasticsearch
 from scrapy.utils.log import configure_logging
 
-from .pipeline.pipelines import RedisStorageClient
+from newsplease.pipeline.pipelines import RedisStorageClient
 
 cur_path = os.path.dirname(os.path.realpath(__file__))
 par_path = os.path.dirname(cur_path)

--- a/newsplease/config/config.cfg
+++ b/newsplease/config/config.cfg
@@ -41,6 +41,10 @@ fallbacks = {
 # In case the check fails, the next crawler in the pipeline will be used
 check_crawler_has_urls_to_scan = False
 
+# Check that the site uses a certificate which is valid and not expired
+# Default: True
+check_certificate = True
+
 # Determines how many hours need to pass since the last download of a webpage
 # to be downloaded again by the RssCrawler
 # default: 6

--- a/newsplease/crawler/spiders/download_crawler.py
+++ b/newsplease/crawler/spiders/download_crawler.py
@@ -42,13 +42,14 @@ class Download(NewspleaseSpider, scrapy.Spider):
         )
 
     @staticmethod
-    def supports_site(url):
+    def supports_site(url: str, check_certificate: bool = True) -> bool:
         """
         As long as the url exists, this crawler will work!
 
         Determines if this crawler works on the given url.
 
         :param str url: The url to test
+        :param str check_certificate:
         :return bool: Determines wether this crawler work on the given url
         """
         return True

--- a/newsplease/crawler/spiders/gdelt_crawler.py
+++ b/newsplease/crawler/spiders/gdelt_crawler.py
@@ -104,13 +104,14 @@ class GdeltCrawler(NewspleaseSpider, scrapy.Spider):
         return True
 
     @staticmethod
-    def supports_site(url):
+    def supports_site(url: str, check_certificate: bool = True) -> bool:
         """
         Rss Crawler is supported if the url is a valid rss feed
 
         Determines if this crawler works on the given url.
 
         :param str url: The url to test
+        :param str check_certificate:
         :return bool: Determines wether this crawler work on the given url
         """
 

--- a/newsplease/crawler/spiders/newsplease_spider.py
+++ b/newsplease/crawler/spiders/newsplease_spider.py
@@ -9,21 +9,23 @@ class NewspleaseSpider(ABC):
 
     @staticmethod
     @abstractmethod
-    def supports_site(url: str) -> bool:
+    def supports_site(url: str, check_certificate: bool = True) -> bool:
         """
         Determines if this spider works on the given URL.
 
         :param str url: The url to test
+        :param bool check_certificate: The url to test
         :return bool:
         """
         pass
 
     @staticmethod
-    def has_urls_to_scan(url: str) -> bool:
+    def has_urls_to_scan(url: str, check_certificate: bool = True) -> bool:
         """
         Determines if this spider has any URLs to scan.
 
         :param str url: The url to test
+        :param bool check_certificate:
         :return bool:
         """
         return True

--- a/newsplease/crawler/spiders/recursive_crawler.py
+++ b/newsplease/crawler/spiders/recursive_crawler.py
@@ -56,13 +56,14 @@ class RecursiveCrawler(NewspleaseSpider, scrapy.Spider):
             response, self.allowed_domains[0], self.original_url)
 
     @staticmethod
-    def supports_site(url):
+    def supports_site(url: str, check_certificate: bool = True) -> bool:
         """
         Recursive Crawler are supported by every site!
 
         Determines if this crawler works on the given url.
 
         :param str url: The url to test
+        :param bool check_certificate:
         :return bool: Determines wether this crawler work on the given url
         """
         return True

--- a/newsplease/crawler/spiders/recursive_sitemap_crawler.py
+++ b/newsplease/crawler/spiders/recursive_sitemap_crawler.py
@@ -35,8 +35,13 @@ class RecursiveSitemapCrawler(NewspleaseSpider, scrapy.spiders.SitemapSpider):
         self.original_url = url
 
         self.allowed_domains = [self.helper.url_extractor.get_allowed_domain(url)]
+        self.check_certificate = (bool(config.section("Crawler").get('check_certificate'))
+                                  if config.section("Crawler").get('check_certificate') is not None
+                                  else True)
         self.sitemap_urls = self.helper.url_extractor.get_sitemap_urls(
-            url, config.section("Crawler")["sitemap_allow_subdomains"]
+            domain_url=url,
+            allow_subdomains=config.section("Crawler")["sitemap_allow_subdomains"],
+            check_certificate=self.check_certificate,
         )
         super(RecursiveSitemapCrawler, self).__init__(*args, **kwargs)
 
@@ -60,7 +65,7 @@ class RecursiveSitemapCrawler(NewspleaseSpider, scrapy.spiders.SitemapSpider):
         )
 
     @staticmethod
-    def supports_site(url):
+    def supports_site(url: str, check_certificate: bool = True) -> bool:
         """
         Sitemap-Crawler are supported by every site which have a
         Sitemap set in the robots.txt.
@@ -68,6 +73,7 @@ class RecursiveSitemapCrawler(NewspleaseSpider, scrapy.spiders.SitemapSpider):
         Determines if this crawler works on the given url.
 
         :param str url: The url to test
+        :param bool check_certificate:
         :return bool: Determines wether this crawler work on the given url
         """
-        return UrlExtractor.sitemap_check(url)
+        return UrlExtractor.sitemap_check(url=url, check_certificate=check_certificate)

--- a/newsplease/crawler/spiders/sitemap_crawler.py
+++ b/newsplease/crawler/spiders/sitemap_crawler.py
@@ -23,6 +23,7 @@ class SitemapCrawler(NewspleaseSpider, scrapy.spiders.SitemapSpider):
 
         self.config = config
         self.helper = helper
+
         self.original_url = url
 
         self.allowed_domains = [
@@ -30,8 +31,13 @@ class SitemapCrawler(NewspleaseSpider, scrapy.spiders.SitemapSpider):
                 url, config.section("Crawler")["sitemap_allow_subdomains"]
             )
         ]
+        self.check_certificate = (bool(config.section("Crawler").get('check_certificate'))
+                                  if config.section("Crawler").get('check_certificate') is not None
+                                  else True)
         self.sitemap_urls = self.helper.url_extractor.get_sitemap_urls(
-            url, config.section("Crawler")["sitemap_allow_subdomains"]
+            domain_url=url,
+            allow_subdomains=config.section("Crawler")["sitemap_allow_subdomains"],
+            check_certificate=self.check_certificate,
         )
 
         self.log.debug(self.sitemap_urls)
@@ -61,7 +67,7 @@ class SitemapCrawler(NewspleaseSpider, scrapy.spiders.SitemapSpider):
         return True
 
     @staticmethod
-    def supports_site(url):
+    def supports_site(url: str, check_certificate: bool = True) -> bool:
         """
         Sitemap-Crawler are supported by every site which have a
         Sitemap set in the robots.txt.
@@ -69,7 +75,8 @@ class SitemapCrawler(NewspleaseSpider, scrapy.spiders.SitemapSpider):
         Determines if this crawler works on the given url.
 
         :param str url: The url to test
+        :param str check_certificate:
         :return bool: Determines wether this crawler work on the given url
         """
 
-        return UrlExtractor.sitemap_check(url)
+        return UrlExtractor.sitemap_check(url=url, check_certificate=check_certificate)

--- a/newsplease/single_crawler.py
+++ b/newsplease/single_crawler.py
@@ -197,6 +197,9 @@ class SingleCrawler(object):
         :rtype: crawler-class or None
         """
         check_crawler_has_urls_to_scan = self.cfg_crawler.get('check_crawler_has_urls_to_scan')
+        check_certificate = (bool(self.cfg_crawler.get('check_certificate'))
+                             if self.cfg_crawler.get('check_certificate') is not None
+                             else True)
 
         checked_crawlers = []
         while crawler is not None and crawler not in checked_crawlers:
@@ -208,13 +211,15 @@ class SingleCrawler(object):
                 return current
 
             try:
-                crawler_supports_site = current.supports_site(url)
+                crawler_supports_site = current.supports_site(url=url, check_certificate=check_certificate)
             except Exception as e:
                 self.log.info(f'Crawler not supported due to: {str(e)}', exc_info=True)
                 crawler_supports_site = False
 
             if crawler_supports_site:
-                if check_crawler_has_urls_to_scan and not current.has_urls_to_scan(url):
+                if (check_crawler_has_urls_to_scan
+                        and not current.has_urls_to_scan(url=url, check_certificate=check_certificate)
+                ):
                     self.log.warning(f"Crawler {crawler} has no url to scan for {url}")
                 else:
                     self.log.debug("Using crawler %s for %s.", crawler, url)


### PR DESCRIPTION
Hello @fhamborg ,

For the context, I'd like to use news-please on websites that have a certificate that is not valid or expired.

In this pull request, I'm adding a new configuration option to enable or disable the verification of the certificate. By default this option is True, so we are checking the certificate like it is done today, if the option is not set it defaults to True.

Tell me if you have any question