### PR TITLE
Pass optional arguments to requests.get

### DIFF
--- a/newsplease/__init__.py
+++ b/newsplease/__init__.py
@@ -111,7 +111,7 @@ class NewsPlease:
         return final_article
 
     @staticmethod
-    def from_url(url, timeout=None, user_agent=None, **kwargs):
+    def from_url(url, timeout=None, user_agent=None, request_args=None):
         """
         Crawls the article from the url and extracts relevant information.
         :param url:
@@ -119,14 +119,14 @@ class NewsPlease:
         :return: A NewsArticle object containing all the information of the article. Else, None.
         :rtype: NewsArticle, None
         """
-        articles = NewsPlease.from_urls([url], timeout=timeout, user_agent=user_agent, **kwargs)
+        articles = NewsPlease.from_urls([url], timeout=timeout, user_agent=user_agent, request_args=request_args)
         if url in articles.keys():
             return articles[url]
         else:
             return None
 
     @staticmethod
-    def from_urls(urls, timeout=None, user_agent=None, **kwargs):
+    def from_urls(urls, timeout=None, user_agent=None, request_args=None):
         """
         Crawls articles from the urls and extracts relevant information.
         :param urls:
@@ -142,10 +142,10 @@ class NewsPlease:
             pass
         elif len(urls) == 1:
             url = urls[0]
-            html = SimpleCrawler.fetch_url(url, timeout=timeout, user_agent=user_agent, **kwargs)
+            html = SimpleCrawler.fetch_url(url, timeout=timeout, user_agent=user_agent, request_args=request_args)
             results[url] = NewsPlease.from_html(html, url, download_date)
         else:
-            results = SimpleCrawler.fetch_urls(urls, timeout=timeout, user_agent=user_agent, **kwargs)
+            results = SimpleCrawler.fetch_urls(urls, timeout=timeout, user_agent=user_agent, request_args=request_args)
 
             futures = {}
             with cf.ProcessPoolExecutor() as exec:

--- a/newsplease/__init__.py
+++ b/newsplease/__init__.py
@@ -111,26 +111,26 @@ class NewsPlease:
         return final_article
 
     @staticmethod
-    def from_url(url, timeout=None, user_agent=None, request_args=None):
+    def from_url(url, request_args=None):
         """
         Crawls the article from the url and extracts relevant information.
         :param url:
-        :param timeout: in seconds, if None, the urllib default is used
+        :param request_args: optional arguments that `request` takes
         :return: A NewsArticle object containing all the information of the article. Else, None.
         :rtype: NewsArticle, None
         """
-        articles = NewsPlease.from_urls([url], timeout=timeout, user_agent=user_agent, request_args=request_args)
+        articles = NewsPlease.from_urls([url], request_args=request_args)
         if url in articles.keys():
             return articles[url]
         else:
             return None
 
     @staticmethod
-    def from_urls(urls, timeout=None, user_agent=None, request_args=None):
+    def from_urls(urls, request_args=None):
         """
         Crawls articles from the urls and extracts relevant information.
         :param urls:
-        :param timeout: in seconds, if None, the urllib default is used
+        :param request_args: optional arguments that `request` takes
         :return: A dict containing given URLs as keys, and extracted information as corresponding values.
         """
         results = {}
@@ -142,10 +142,10 @@ class NewsPlease:
             pass
         elif len(urls) == 1:
             url = urls[0]
-            html = SimpleCrawler.fetch_url(url, timeout=timeout, user_agent=user_agent, request_args=request_args)
+            html = SimpleCrawler.fetch_url(url, request_args=request_args)
             results[url] = NewsPlease.from_html(html, url, download_date)
         else:
-            results = SimpleCrawler.fetch_urls(urls, timeout=timeout, user_agent=user_agent, request_args=request_args)
+            results = SimpleCrawler.fetch_urls(urls, request_args=request_args)
 
             futures = {}
             with cf.ProcessPoolExecutor() as exec:
@@ -158,7 +158,7 @@ class NewsPlease:
             for future in cf.as_completed(futures):
                 url = futures[future]
                 try:
-                    results[url] = future.result(timeout=timeout)
+                    results[url] = future.result(timeout=request_args.get("timeout"))
                 except Exception as err:
                     results[url] = {}
 

--- a/newsplease/__init__.py
+++ b/newsplease/__init__.py
@@ -111,7 +111,7 @@ class NewsPlease:
         return final_article
 
     @staticmethod
-    def from_url(url, timeout=None, user_agent=None):
+    def from_url(url, timeout=None, user_agent=None, **kwargs):
         """
         Crawls the article from the url and extracts relevant information.
         :param url:
@@ -119,14 +119,14 @@ class NewsPlease:
         :return: A NewsArticle object containing all the information of the article. Else, None.
         :rtype: NewsArticle, None
         """
-        articles = NewsPlease.from_urls([url], timeout=timeout, user_agent=user_agent)
+        articles = NewsPlease.from_urls([url], timeout=timeout, user_agent=user_agent, **kwargs)
         if url in articles.keys():
             return articles[url]
         else:
             return None
 
     @staticmethod
-    def from_urls(urls, timeout=None, user_agent=None):
+    def from_urls(urls, timeout=None, user_agent=None, **kwargs):
         """
         Crawls articles from the urls and extracts relevant information.
         :param urls:
@@ -142,10 +142,10 @@ class NewsPlease:
             pass
         elif len(urls) == 1:
             url = urls[0]
-            html = SimpleCrawler.fetch_url(url, timeout=timeout, user_agent=user_agent)
+            html = SimpleCrawler.fetch_url(url, timeout=timeout, user_agent=user_agent, **kwargs)
             results[url] = NewsPlease.from_html(html, url, download_date)
         else:
-            results = SimpleCrawler.fetch_urls(urls, timeout=timeout, user_agent=user_agent)
+            results = SimpleCrawler.fetch_urls(urls, timeout=timeout, user_agent=user_agent, **kwargs)
 
             futures = {}
             with cf.ProcessPoolExecutor() as exec:

--- a/newsplease/crawler/simple_crawler.py
+++ b/newsplease/crawler/simple_crawler.py
@@ -28,17 +28,17 @@ class SimpleCrawler(object):
     _results = {}
 
     @staticmethod
-    def fetch_url(url, timeout=None, user_agent=USER_AGENT):
+    def fetch_url(url, timeout=None, user_agent=USER_AGENT, **kwargs):
         """
         Crawls the html content of the parameter url and returns the html
         :param url:
         :param timeout: in seconds, if None, the urllib default is used
         :return:
         """
-        return SimpleCrawler._fetch_url(url, False, timeout=timeout, user_agent=user_agent)
+        return SimpleCrawler._fetch_url(url, False, timeout=timeout, user_agent=user_agent, **kwargs)
 
     @staticmethod
-    def _fetch_url(url, is_threaded, timeout=None, user_agent=USER_AGENT):
+    def _fetch_url(url, is_threaded, timeout=None, user_agent=USER_AGENT, **kwargs):
         """
         Crawls the html content of the parameter url and saves the html in _results
         :param url:
@@ -61,6 +61,7 @@ class SimpleCrawler(object):
                 verify=False,
                 allow_redirects=True,
                 headers=headers,
+                **kwargs
             )
         except (requests.exceptions.MissingSchema, requests.exceptions.InvalidURL):
             LOGGER.error("malformed URL: %s", url)
@@ -91,7 +92,7 @@ class SimpleCrawler(object):
         return html_str
 
     @staticmethod
-    def fetch_urls(urls, timeout=None, user_agent=USER_AGENT):
+    def fetch_urls(urls, timeout=None, user_agent=USER_AGENT, **kwargs):
         """
         Crawls the html content of all given urls in parallel. Returns when all requests are processed.
         :param urls:
@@ -99,7 +100,7 @@ class SimpleCrawler(object):
         :return:
         """
         threads = [
-            threading.Thread(target=SimpleCrawler._fetch_url, args=(url, True, timeout, user_agent))
+            threading.Thread(target=SimpleCrawler._fetch_url, args=(url, True, timeout, user_agent), kwargs=kwargs)
             for url in urls
         ]
         for thread in threads:

--- a/newsplease/crawler/simple_crawler.py
+++ b/newsplease/crawler/simple_crawler.py
@@ -28,17 +28,17 @@ class SimpleCrawler(object):
     _results = {}
 
     @staticmethod
-    def fetch_url(url, timeout=None, user_agent=USER_AGENT, **kwargs):
+    def fetch_url(url, timeout=None, user_agent=USER_AGENT, request_args=None):
         """
         Crawls the html content of the parameter url and returns the html
         :param url:
         :param timeout: in seconds, if None, the urllib default is used
         :return:
         """
-        return SimpleCrawler._fetch_url(url, False, timeout=timeout, user_agent=user_agent, **kwargs)
+        return SimpleCrawler._fetch_url(url, False, timeout=timeout, user_agent=user_agent, request_args=request_args)
 
     @staticmethod
-    def _fetch_url(url, is_threaded, timeout=None, user_agent=USER_AGENT, **kwargs):
+    def _fetch_url(url, is_threaded, timeout=None, user_agent=USER_AGENT, request_args=None):
         """
         Crawls the html content of the parameter url and saves the html in _results
         :param url:
@@ -61,7 +61,7 @@ class SimpleCrawler(object):
                 verify=False,
                 allow_redirects=True,
                 headers=headers,
-                **kwargs
+                **(request_args or {})
             )
         except (requests.exceptions.MissingSchema, requests.exceptions.InvalidURL):
             LOGGER.error("malformed URL: %s", url)
@@ -92,7 +92,7 @@ class SimpleCrawler(object):
         return html_str
 
     @staticmethod
-    def fetch_urls(urls, timeout=None, user_agent=USER_AGENT, **kwargs):
+    def fetch_urls(urls, timeout=None, user_agent=USER_AGENT, request_args=None):
         """
         Crawls the html content of all given urls in parallel. Returns when all requests are processed.
         :param urls:
@@ -100,7 +100,7 @@ class SimpleCrawler(object):
         :return:
         """
         threads = [
-            threading.Thread(target=SimpleCrawler._fetch_url, args=(url, True, timeout, user_agent), kwargs=kwargs)
+            threading.Thread(target=SimpleCrawler._fetch_url, args=(url, True, timeout, user_agent, request_args))
             for url in urls
         ]
         for thread in threads:


### PR DESCRIPTION
It would be beneficial if users could pass optional arguments, such as authentication information and proxy configurations, to requests made by `NewsPlease.from_url` and `NewsPlease.from_urls`.

This PR adds `**kwargs` to the above functions and passes them to `requests.get` in `SimpleCrawler._fetch_url`.


With this change, users can add authentication information like this:

```python
from newsplease import NewsPlease
from requests.auth import HTTPBasicAuth

NewsPlease.from_url("https://example.com", auth=HTTPBasicAuth("user", "password"))
```

and also add proxy configurations like this:

```python
from newsplease import NewsPlease

proxies = {
    "http": "http://10.10.1.10:3128",
    "https": "http://10.10.1.10:1080",
}

NewsPlease.from_url("https://example.com", proxies=proxies)
```

Related to #234 and https://github.com/fhamborg/news-please/discussions/254.