### PR TITLE
Add missing dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ bs4
 faust-cchardet>=2.1.18
 boto3
 typing-extensions>=4.7.0
+redis


### PR DESCRIPTION
It looks like `requirements.txt` is missing some dependencies.

This PR adds the necessary dependencies to ensure it matches `setup.py`.
