### PR TITLE
Allow the RssCrawler to search for an RSS feed from the provided url

### DIFF
--- a/newsplease/config/config.cfg
+++ b/newsplease/config/config.cfg
@@ -100,6 +100,17 @@ sitemap_allow_subdomains = True
 # default: [] which means there will be no sitemap check
 sitemap_patterns = []
 
+# Set of Rss parent pages
+# Allow to force the check of specific pages for an existing rss feed if it cannot be found from the homepage
+# Here is an example of definition:
+# rss_parent_pages = [
+#   "",
+#   "blog",
+#   "actualite",
+#   ]
+# default: [] which means there will be no RSS check
+rss_parent_pages = ['']
+
 
 [Heuristics]
 

--- a/newsplease/config/config_lib.cfg
+++ b/newsplease/config/config_lib.cfg
@@ -86,6 +86,33 @@ ignore_regex = "(mail[tT]o)|([jJ]avascript)|(tel)|(fax)"
 # default: True
 sitemap_allow_subdomains = True
 
+# Set of sitemap patterns
+# Allow to force the check of specific sitemaps if it's absent from robots.txt.
+# Here is an example of definition:
+# sitemap_patterns = [
+#   "sitemap.xml",
+#   "post-sitemap.xml",
+#   "blog-posts-sitemap.xml",
+#   "sitemaps/post-sitemap.xml",
+#   "sitemap_index.xml",
+#   "sitemaps/sitemap_index.xml",
+#   "sitemaps/sitemap.xml",
+#   "sitemaps/sitemap-articles.xml"
+#   ]
+# default: [] which means there will be no sitemap check
+sitemap_patterns = []
+
+# Set of Rss parent pages
+# Allow to force the check of specific pages for an existing rss feed if it cannot be found from the homepage
+# Here is an example of definition:
+# rss_parent_pages = [
+#   "",
+#   "blog",
+#   "actualite",
+#   ]
+# default: [] which means there will be no RSS check
+rss_parent_pages = ['']
+
 
 
 [Heuristics]

--- a/newsplease/crawler/spiders/rss_crawler.py
+++ b/newsplease/crawler/spiders/rss_crawler.py
@@ -108,7 +108,7 @@ class RssCrawler(NewspleaseSpider, scrapy.Spider):
     @staticmethod
     def _get_rss_start_urls(url: str, check_certificate: bool = True) -> list[str]:
         config = CrawlerConfig.get_instance()
-        rss_patterns = config.section("Crawler").get("rss_parent_pages", [])
+        rss_patterns = config.section("Crawler").get("rss_parent_pages", [''])
 
         valid_start_urls = []
         for pattern in rss_patterns:


### PR DESCRIPTION
Hello @fhamborg ,

Here is an improvement for the RssCrawler. Some websites provide an RSS feed that is only accessible from specific pages and I would like to be able to use the RssCrawler on those sites. The current behaviour is that the RssCrawler looks for the RSS feed from the base page.
For example the website https://www.weka.fr/actualite/ provides an RSS feed, but it is not accessible from https://www.weka.fr/

In this pull request, I'm adding a new configuration option `crawl_from_base_domain_by_rss_crawler` that by default keeps the current behaviour of checking the for an RSS feed from the base url, and if set to False will allow to search for an RSS feed from the provided url

Tell me if you have any question