### PR TITLE
Adds support for exporting to OpenSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,34 @@ That's it! Except, if your Elasticsearch database is not located at `http://loca
     username = 'root'  
     secret = 'password'
 
+### OpenSearch
+
+news-please supports export to OpenSearch. OpenSearch is the same as ElasticSearch with minor differences in the client implementation, so has same features that ElasticSearch
+
+Example pipline settings
+    [Scrapy]
+
+    ITEM_PIPELINES = {
+                       'newsplease.pipeline.pipelines.ArticleMasterExtractor':100,
+                       'newsplease.pipeline.pipelines.OpensearchStorage':350
+                     }
+
+if your Opensearch database is not located at `http://localhost:9200`, uses a different username/password or CA-certificate authentication. In these cases, you will also need to change the following.
+
+    [Opensearch]
+
+    host = localhost
+    port = 9200    
+    # means that requesth should be send through https
+    use_ssl = True 
+
+    ...
+
+    # Credentials used  for authentication
+    username = 'root'  
+    secret = 'password'
+
+
 ### PostgreSQL
 news-please allows for storing of articles to a PostgreSQL database, including the versioning feature. To export to PostgreSQL, open the corresponding config file (`config_lib.cfg` for library mode and `config.cfg` for CLI mode) and add the PostgresqlStorage module to the pipeline and adjust the database credentials:
 

--- a/newsplease/config/config.cfg
+++ b/newsplease/config/config.cfg
@@ -264,6 +264,46 @@ mapping = {"properties": {
     }}
 
 
+[Opensearch]
+
+# Elasticsearch-Connection required for saving detailed meta-information
+host = 'localhost'
+port = 9200
+use_ssl = True
+index_current = 'news-please'
+index_archive = 'news-please-archive'
+
+# Opensearch supports user authentication by CA certificates, but not implemented yet
+# use_ca_certificates = False
+# ca_cert_path = /path/to/cacert.pem
+# client_cert_path = /path/to/client_cert.pem
+# client_key_path = /path/to/client_key.pem
+username = 'root'
+secret = 'password'
+
+# Properties of the document type used for storage.
+mapping = {"properties": {
+    "url": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "source_domain": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "title_page": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "title_rss": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "localpath": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "filename": {"type": "keyword"},
+    "ancestor": {"type": "keyword"},
+    "descendant": {"type": "keyword"},
+    "version": {"type": "long"},
+    "date_download": {"type": "date", "format":"yyyy-MM-dd HH:mm:ss"},
+    "date_modify": {"type": "date", "format":"yyyy-MM-dd HH:mm:ss"},
+    "date_publish": {"type": "date", "format":"yyyy-MM-dd HH:mm:ss"},
+    "title": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "description":  {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "text": {"type": "text"},
+    "authors": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "image_url":  {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "language": {"type": "keyword"}
+    }}
+
+
 [Redis]
 
 # Redis required for saving meta-information

--- a/newsplease/config/config_lib.cfg
+++ b/newsplease/config/config_lib.cfg
@@ -251,6 +251,46 @@ mapping = {
     }
 
 
+[Opensearch]
+
+# Elasticsearch-Connection required for saving detailed meta-information
+host = 'localhost'
+port = 9200
+use_ssl = True
+index_current = 'news-please'
+index_archive = 'news-please-archive'
+
+# Opensearch supports user authentication by CA certificates, but not implemented yet
+# use_ca_certificates = False
+# ca_cert_path = /path/to/cacert.pem
+# client_cert_path = /path/to/client_cert.pem
+# client_key_path = /path/to/client_key.pem
+username = 'root'
+secret = 'password'
+
+# Properties of the document type used for storage.
+mapping = {"properties": {
+    "url": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "source_domain": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "title_page": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "title_rss": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "localpath": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "filename": {"type": "keyword"},
+    "ancestor": {"type": "keyword"},
+    "descendant": {"type": "keyword"},
+    "version": {"type": "long"},
+    "date_download": {"type": "date", "format":"yyyy-MM-dd HH:mm:ss"},
+    "date_modify": {"type": "date", "format":"yyyy-MM-dd HH:mm:ss"},
+    "date_publish": {"type": "date", "format":"yyyy-MM-dd HH:mm:ss"},
+    "title": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "description":  {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "text": {"type": "text"},
+    "authors": {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "image_url":  {"type": "text","fields":{"keyword":{"type":"keyword"}}},
+    "language": {"type": "keyword"}
+    }}
+
+
 [Redis]
 
 # Redis required for saving meta-information

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ PyMySQL>=0.7.9
 psycopg2-binary>=2.8.4
 hjson>=1.5.8
 elasticsearch>=2.4
+opensearch-py>=2.7
 beautifulsoup4>=4.3.2
 readability-lxml>=0.6.2
 langdetect>=1.0.7

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ news-please is an open source, easy-to-use news crawler that extracts structured
         "psycopg2-binary>=2.8.4",
         "hjson>=1.5.8",
         "elasticsearch>=2.4",
+        "opensearch-py>=2.7",
         "beautifulsoup4>=4.3.2",
         "readability-lxml>=0.6.2",
         "langdetect>=1.0.7",


### PR DESCRIPTION
here is support for exporting to OpenSearch. The current integration with ElasticSearch was not compatible with the latest version of OpenSearch, despite the APIs being roughly similar