### PR TITLE
Fix request_url return value

### DIFF
--- a/newsplease/helper_classes/url_extractor.py
+++ b/newsplease/helper_classes/url_extractor.py
@@ -85,7 +85,7 @@ class UrlExtractor(object):
 
         if check_certificate:
             opener = urllib2.build_opener(urllib2.HTTPRedirectHandler)
-            return opener.open(request).url
+            return opener.open(request)
 
         context = ssl.create_default_context()
         context.check_hostname = False


### PR DESCRIPTION
Hi @fhamborg 👋 

After moving `follow_redirects` in `request_url` method, the function were still returning a str instead of HTTPResponse