### PR TITLE
Retrieve URL redirection from parsed URL instead of allowed domain

### DIFF
--- a/newsplease/helper_classes/url_extractor.py
+++ b/newsplease/helper_classes/url_extractor.py
@@ -131,12 +131,22 @@ class UrlExtractor(object):
         :return: the robot.txt's HTTP response or None if it's not retrieved
         """
         parsed_url = urlparse(url)
-        redirect_url = UrlExtractor.follow_redirects(
-            url="{scheme}://{url_netloc}".format(
-                scheme=parsed_url.scheme, url_netloc=parsed_url.netloc
-            ),
-            check_certificate=check_certificate,
-        )
+        try:
+            redirect_url = UrlExtractor.follow_redirects(
+                url="{scheme}://{url_netloc}".format(
+                    scheme=parsed_url.scheme, url_netloc=parsed_url.netloc
+                ),
+                check_certificate=check_certificate,
+            )
+        except URLError:
+            # Try without www.
+            redirect_url = UrlExtractor.follow_redirects(
+                url="{scheme}://".format(scheme=parsed_url.scheme)
+                + UrlExtractor.get_allowed_domain(
+                    url, allow_subdomains=allow_subdomains
+                ),
+                check_certificate=check_certificate,
+            )
 
         # Get robots.txt
         parsed_redirection = urlparse(redirect_url)

--- a/newsplease/helper_classes/url_extractor.py
+++ b/newsplease/helper_classes/url_extractor.py
@@ -130,20 +130,25 @@ class UrlExtractor(object):
                                       subdomain's
         :return: the robot.txt's HTTP response or None if it's not retrieved
         """
+        parsed_url = urlparse(url)
         redirect_url = UrlExtractor.follow_redirects(
-            url="http://" + UrlExtractor.get_allowed_domain(url, allow_subdomains=allow_subdomains),
-            check_certificate=check_certificate
+            url="{scheme}://{url_netloc}".format(
+                scheme=parsed_url.scheme, url_netloc=parsed_url.netloc
+            ),
+            check_certificate=check_certificate,
         )
 
         # Get robots.txt
-        parsed = urlparse(redirect_url)
+        parsed_redirection = urlparse(redirect_url)
         if allow_subdomains:
-            url_netloc = parsed.netloc
+            url_netloc = parsed_redirection.netloc
         else:
-            url_netloc = UrlExtractor.get_allowed_domain(parsed.netloc, False)
+            url_netloc = UrlExtractor.get_allowed_domain(
+                parsed_redirection.netloc, False
+            )
 
         robots_url = "{url.scheme}://{url_netloc}/robots.txt".format(
-            url=parsed, url_netloc=url_netloc
+            url=parsed_redirection, url_netloc=url_netloc
         )
         try:
             response = UrlExtractor.request_url(url=robots_url, check_certificate=check_certificate)


### PR DESCRIPTION
Hi @fhamborg 👋 

Looking back at this previous code 
https://github.com/fhamborg/news-please/blob/3d3fd2b9e40747134a373ff0e2cd5880557d7d5e/newsplease/helper_classes/url_extractor.py#L89
, I noticed that the redirection was computed directly using the URL instead of the currently computed allowed domain.

Currently, this can cause issues because the `get_allowed_domain` method removes `www.` from the URL, leading to incorrect queries when a website does not redirect to its www. version.