### PR TITLE
Correct readability extractor

### DIFF
--- a/newsplease/pipeline/extractor/extractors/readability_extractor.py
+++ b/newsplease/pipeline/extractor/extractors/readability_extractor.py
@@ -22,7 +22,7 @@ class ReadabilityExtractor(AbstractExtractor):
         :return: ArticleCandidate containing the recovered article data.
         """
 
-        doc = Document(deepcopy(item['spider_response'].body))
+        doc = Document(deepcopy(item['spider_response'].text))
         description = doc.summary()
 
         article_candidate = ArticleCandidate()

--- a/newsplease/pipeline/extractor/extractors/readability_extractor.py
+++ b/newsplease/pipeline/extractor/extractors/readability_extractor.py
@@ -22,7 +22,7 @@ class ReadabilityExtractor(AbstractExtractor):
         :return: ArticleCandidate containing the recovered article data.
         """
 
-        doc = Document(deepcopy(item['spider_response'].text))
+        doc = Document(deepcopy(item['spider_response'].body))
         description = doc.summary()
 
         article_candidate = ArticleCandidate()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ psycopg2-binary>=2.8.4
 hjson>=1.5.8
 elasticsearch>=2.4
 beautifulsoup4>=4.3.2
-readability-lxml>=0.6.2
+# The 0.8.4.1 version is broken. cf. https://github.com/buriy/python-readability/issues/194
+readability-lxml==0.8.1
 langdetect>=1.0.7
 python-dateutil>=2.4.0
 plac>=0.9.6


### PR DESCRIPTION
Readibilty can instantiate its Documents with byte content, but it cannot then provides summary, title and other attributes since an issue of regexp compatibility. An issue has been opened for this specific subject : https://github.com/buriy/python-readability/issues/194

While waiting for this issue to be processed, this PR sends to Readibility version to 0.8.1 waiting for the correction