### PR TITLE
Add main_content_linked_headlines to heuristics

### DIFF
--- a/newsplease/helper_classes/heuristics.py
+++ b/newsplease/helper_classes/heuristics.py
@@ -162,6 +162,6 @@ class Heuristics(HeuristicsManager):
             encoding="utf-8"
         )
 
-        result = self.linked_headlines(main_text_response, site_dict, True)
+        result = self.linked_headlines(main_text_response, site_dict)
 
         return result


### PR DESCRIPTION
This new heuristic analyzes linked headlines specifically within the main content area of a webpage, rather than across the entire page. This provides more accurate article detection by filtering out navigation elements, sidebars, headers, and footers that may contain numerous linked headlines unrelated to the main content.

The function:
- Extracts the main article content using Newspaper4k's ArticleBodyExtractor
- Applies the existing linked_headlines logic to only the main content area
- Reduces false positives caused by navigation menus and promotional content in peripheral page areas